### PR TITLE
Boring things

### DIFF
--- a/src/domain.rs
+++ b/src/domain.rs
@@ -10,11 +10,9 @@
 //! This allows us to perform polynomial operations in O(n)
 //! by performing an O(n log n) FFT over such a domain.
 
-use pairing::{CurveProjective, Engine, Field, PrimeField};
-
-use super::SynthesisError;
-
 use super::multicore::Worker;
+use super::SynthesisError;
+use pairing::{CurveProjective, Engine, Field, PrimeField};
 
 pub struct EvaluationDomain<E: Engine, G: Group<E>> {
     coeffs: Vec<G>,

--- a/src/domain.rs
+++ b/src/domain.rs
@@ -10,9 +10,9 @@
 //! This allows us to perform polynomial operations in O(n)
 //! by performing an O(n log n) FFT over such a domain.
 
-use super::multicore::Worker;
-use super::SynthesisError;
+use multicore::Worker;
 use pairing::{CurveProjective, Engine, Field, PrimeField};
+use SynthesisError;
 
 pub struct EvaluationDomain<E: Engine, G: Group<E>> {
     coeffs: Vec<G>,

--- a/src/domain.rs
+++ b/src/domain.rs
@@ -26,14 +26,6 @@ pub struct EvaluationDomain<E: Engine, G: Group<E>> {
 }
 
 impl<E: Engine, G: Group<E>> EvaluationDomain<E, G> {
-    pub fn as_ref(&self) -> &[G] {
-        &self.coeffs
-    }
-
-    pub fn as_mut(&mut self) -> &mut [G] {
-        &mut self.coeffs
-    }
-
     pub fn into_coeffs(self) -> Vec<G> {
         self.coeffs
     }
@@ -63,9 +55,9 @@ impl<E: Engine, G: Group<E>> EvaluationDomain<E, G> {
         coeffs.resize(m, G::group_zero());
 
         Ok(EvaluationDomain {
-            coeffs: coeffs,
-            exp: exp,
-            omega: omega,
+            coeffs,
+            exp,
+            omega,
             omegainv: omega.inverse().unwrap(),
             geninv: E::Fr::multiplicative_generator().inverse().unwrap(),
             minv: E::Fr::from_str(&format!("{}", m))
@@ -189,6 +181,18 @@ impl<E: Engine, G: Group<E>> EvaluationDomain<E, G> {
     }
 }
 
+impl<E: Engine, G: Group<E>> AsRef<[G]> for EvaluationDomain<E, G> {
+    fn as_ref(&self) -> &[G] {
+        &self.coeffs
+    }
+}
+
+impl<E: Engine, G: Group<E>> AsMut<[G]> for EvaluationDomain<E, G> {
+    fn as_mut(&mut self) -> &mut [G] {
+        &mut self.coeffs
+    }
+}
+
 pub trait Group<E: Engine>: Sized + Copy + Clone + Send + Sync {
     fn group_zero() -> Self;
     fn group_mul_assign(&mut self, by: &E::Fr);
@@ -290,19 +294,19 @@ fn serial_fft<E: Engine, T: Group<E>>(a: &mut [T], omega: &E::Fr, log_n: u32) {
 
     let mut m = 1;
     for _ in 0..log_n {
-        let w_m = omega.pow(&[(n / (2 * m)) as u64]);
+        let w_m = omega.pow(&[u64::from(n / (2 * m))]);
 
         let mut k = 0;
         while k < n {
-            let mut w = E::Fr::one();
+            let mut ww = E::Fr::one();
             for j in 0..m {
-                let mut t = a[(k + j + m) as usize];
-                t.group_mul_assign(&w);
+                let mut tt = a[(k + j + m) as usize];
+                tt.group_mul_assign(&ww);
                 let mut tmp = a[(k + j) as usize];
-                tmp.group_sub_assign(&t);
+                tmp.group_sub_assign(&tt);
                 a[(k + j + m) as usize] = tmp;
-                a[(k + j) as usize].group_add_assign(&t);
-                w.mul_assign(&w_m);
+                a[(k + j) as usize].group_add_assign(&tt);
+                ww.mul_assign(&w_m);
             }
 
             k += 2 * m;
@@ -336,12 +340,12 @@ fn parallel_fft<E: Engine, T: Group<E>>(
                 let omega_step = omega.pow(&[(j as u64) << log_new_n]);
 
                 let mut elt = E::Fr::one();
-                for i in 0..(1 << log_new_n) {
+                for (i, x) in tmp.iter_mut().enumerate().take(1 << log_new_n) {
                     for s in 0..num_cpus {
                         let idx = (i + (s << log_new_n)) % (1 << log_n);
                         let mut t = a[idx];
                         t.group_mul_assign(&elt);
-                        tmp[i].group_add_assign(&t);
+                        x.group_add_assign(&t);
                         elt.mul_assign(&omega_step);
                     }
                     elt.mul_assign(&omega_j);

--- a/src/groth16/generator.rs
+++ b/src/groth16/generator.rs
@@ -1,16 +1,10 @@
-use rand::Rng;
-
-use std::sync::Arc;
-
-use pairing::{CurveAffine, CurveProjective, Engine, Field, PrimeField, Wnaf};
-
 use super::{Parameters, VerifyingKey};
-
-use {Circuit, ConstraintSystem, Index, LinearCombination, SynthesisError, Variable};
-
 use domain::{EvaluationDomain, Scalar};
-
 use multicore::Worker;
+use pairing::{CurveAffine, CurveProjective, Engine, Field, PrimeField, Wnaf};
+use rand::Rng;
+use std::sync::Arc;
+use {Circuit, ConstraintSystem, Index, LinearCombination, SynthesisError, Variable};
 
 /// Generates a random common reference string for
 /// a circuit.

--- a/src/groth16/generator.rs
+++ b/src/groth16/generator.rs
@@ -151,6 +151,7 @@ impl<E: Engine> ConstraintSystem<E> for KeypairAssembly<E> {
 }
 
 /// Create parameters for a circuit, given some toxic waste.
+#[cfg_attr(feature = "cargo-clippy", allow(too_many_arguments))]
 pub fn generate_parameters<E, C>(
     circuit: C,
     g1: E::G1,
@@ -277,6 +278,7 @@ where
     let mut ic = vec![E::G1::zero(); assembly.num_inputs];
     let mut l = vec![E::G1::zero(); assembly.num_aux];
 
+    #[cfg_attr(feature = "cargo-clippy", allow(too_many_arguments))]
     fn eval<E: Engine>(
         // wNAF window tables
         g1_wnaf: &Wnaf<usize, &[E::G1], &mut Vec<i64>>,
@@ -429,7 +431,7 @@ where
 
     // Don't allow any elements be unconstrained, so that
     // the L query is always fully dense.
-    for e in l.iter() {
+    for e in &l {
         if e.is_zero() {
             return Err(SynthesisError::UnconstrainedVariable);
         }
@@ -449,7 +451,7 @@ where
     };
 
     Ok(Parameters {
-        vk: vk,
+        vk,
         h: Arc::new(h.into_iter().map(|e| e.into_affine()).collect()),
         l: Arc::new(l.into_iter().map(|e| e.into_affine()).collect()),
 

--- a/src/groth16/generator.rs
+++ b/src/groth16/generator.rs
@@ -2,45 +2,26 @@ use rand::Rng;
 
 use std::sync::Arc;
 
-use pairing::{
-    Engine,
-    PrimeField,
-    Field,
-    Wnaf,
-    CurveProjective,
-    CurveAffine
-};
+use pairing::{CurveAffine, CurveProjective, Engine, Field, PrimeField, Wnaf};
 
-use super::{
-    Parameters,
-    VerifyingKey
-};
+use super::{Parameters, VerifyingKey};
 
-use ::{
-    SynthesisError,
-    Circuit,
-    ConstraintSystem,
-    LinearCombination,
-    Variable,
-    Index
-};
+use {Circuit, ConstraintSystem, Index, LinearCombination, SynthesisError, Variable};
 
-use ::domain::{
-    EvaluationDomain,
-    Scalar
-};
+use domain::{EvaluationDomain, Scalar};
 
-use ::multicore::{
-    Worker
-};
+use multicore::Worker;
 
 /// Generates a random common reference string for
 /// a circuit.
 pub fn generate_random_parameters<E, C, R>(
     circuit: C,
-    rng: &mut R
+    rng: &mut R,
 ) -> Result<Parameters<E>, SynthesisError>
-    where E: Engine, C: Circuit<E>, R: Rng
+where
+    E: Engine,
+    C: Circuit<E>,
+    R: Rng,
 {
     let g1 = rng.gen();
     let g2 = rng.gen();
@@ -50,16 +31,7 @@ pub fn generate_random_parameters<E, C, R>(
     let delta = rng.gen();
     let tau = rng.gen();
 
-    generate_parameters::<E, C>(
-        circuit,
-        g1,
-        g2,
-        alpha,
-        beta,
-        gamma,
-        delta,
-        tau
-    )
+    generate_parameters::<E, C>(circuit, g1, g2, alpha, beta, gamma, delta, tau)
 }
 
 /// This is our assembly structure that we'll use to synthesize the
@@ -73,18 +45,17 @@ struct KeypairAssembly<E: Engine> {
     ct_inputs: Vec<Vec<(E::Fr, usize)>>,
     at_aux: Vec<Vec<(E::Fr, usize)>>,
     bt_aux: Vec<Vec<(E::Fr, usize)>>,
-    ct_aux: Vec<Vec<(E::Fr, usize)>>
+    ct_aux: Vec<Vec<(E::Fr, usize)>>,
 }
 
 impl<E: Engine> ConstraintSystem<E> for KeypairAssembly<E> {
     type Root = Self;
 
-    fn alloc<F, A, AR>(
-        &mut self,
-        _: A,
-        _: F
-    ) -> Result<Variable, SynthesisError>
-        where F: FnOnce() -> Result<E::Fr, SynthesisError>, A: FnOnce() -> AR, AR: Into<String>
+    fn alloc<F, A, AR>(&mut self, _: A, _: F) -> Result<Variable, SynthesisError>
+    where
+        F: FnOnce() -> Result<E::Fr, SynthesisError>,
+        A: FnOnce() -> AR,
+        AR: Into<String>,
     {
         // There is no assignment, so we don't even invoke the
         // function for obtaining one.
@@ -99,12 +70,11 @@ impl<E: Engine> ConstraintSystem<E> for KeypairAssembly<E> {
         Ok(Variable(Index::Aux(index)))
     }
 
-    fn alloc_input<F, A, AR>(
-        &mut self,
-        _: A,
-        _: F
-    ) -> Result<Variable, SynthesisError>
-        where F: FnOnce() -> Result<E::Fr, SynthesisError>, A: FnOnce() -> AR, AR: Into<String>
+    fn alloc_input<F, A, AR>(&mut self, _: A, _: F) -> Result<Variable, SynthesisError>
+    where
+        F: FnOnce() -> Result<E::Fr, SynthesisError>,
+        A: FnOnce() -> AR,
+        AR: Into<String>,
     {
         // There is no assignment, so we don't even invoke the
         // function for obtaining one.
@@ -119,48 +89,59 @@ impl<E: Engine> ConstraintSystem<E> for KeypairAssembly<E> {
         Ok(Variable(Index::Input(index)))
     }
 
-    fn enforce<A, AR, LA, LB, LC>(
-        &mut self,
-        _: A,
-        a: LA,
-        b: LB,
-        c: LC
-    )
-        where A: FnOnce() -> AR, AR: Into<String>,
-              LA: FnOnce(LinearCombination<E>) -> LinearCombination<E>,
-              LB: FnOnce(LinearCombination<E>) -> LinearCombination<E>,
-              LC: FnOnce(LinearCombination<E>) -> LinearCombination<E>
+    fn enforce<A, AR, LA, LB, LC>(&mut self, _: A, a: LA, b: LB, c: LC)
+    where
+        A: FnOnce() -> AR,
+        AR: Into<String>,
+        LA: FnOnce(LinearCombination<E>) -> LinearCombination<E>,
+        LB: FnOnce(LinearCombination<E>) -> LinearCombination<E>,
+        LC: FnOnce(LinearCombination<E>) -> LinearCombination<E>,
     {
         fn eval<E: Engine>(
             l: LinearCombination<E>,
             inputs: &mut [Vec<(E::Fr, usize)>],
             aux: &mut [Vec<(E::Fr, usize)>],
-            this_constraint: usize
-        )
-        {
+            this_constraint: usize,
+        ) {
             for (index, coeff) in l.0 {
                 match index {
                     Variable(Index::Input(id)) => inputs[id].push((coeff, this_constraint)),
-                    Variable(Index::Aux(id)) => aux[id].push((coeff, this_constraint))
+                    Variable(Index::Aux(id)) => aux[id].push((coeff, this_constraint)),
                 }
             }
         }
 
-        eval(a(LinearCombination::zero()), &mut self.at_inputs, &mut self.at_aux, self.num_constraints);
-        eval(b(LinearCombination::zero()), &mut self.bt_inputs, &mut self.bt_aux, self.num_constraints);
-        eval(c(LinearCombination::zero()), &mut self.ct_inputs, &mut self.ct_aux, self.num_constraints);
+        eval(
+            a(LinearCombination::zero()),
+            &mut self.at_inputs,
+            &mut self.at_aux,
+            self.num_constraints,
+        );
+        eval(
+            b(LinearCombination::zero()),
+            &mut self.bt_inputs,
+            &mut self.bt_aux,
+            self.num_constraints,
+        );
+        eval(
+            c(LinearCombination::zero()),
+            &mut self.ct_inputs,
+            &mut self.ct_aux,
+            self.num_constraints,
+        );
 
         self.num_constraints += 1;
     }
 
     fn push_namespace<NR, N>(&mut self, _: N)
-        where NR: Into<String>, N: FnOnce() -> NR
+    where
+        NR: Into<String>,
+        N: FnOnce() -> NR,
     {
         // Do nothing; we don't care about namespaces in this context.
     }
 
-    fn pop_namespace(&mut self)
-    {
+    fn pop_namespace(&mut self) {
         // Do nothing; we don't care about namespaces in this context.
     }
 
@@ -178,9 +159,11 @@ pub fn generate_parameters<E, C>(
     beta: E::Fr,
     gamma: E::Fr,
     delta: E::Fr,
-    tau: E::Fr
+    tau: E::Fr,
 ) -> Result<Parameters<E>, SynthesisError>
-    where E: Engine, C: Circuit<E>
+where
+    E: Engine,
+    C: Circuit<E>,
 {
     let mut assembly = KeypairAssembly {
         num_inputs: 0,
@@ -191,7 +174,7 @@ pub fn generate_parameters<E, C>(
         ct_inputs: vec![],
         at_aux: vec![],
         bt_aux: vec![],
-        ct_aux: vec![]
+        ct_aux: vec![],
     };
 
     // Allocate the "one" input variable
@@ -203,11 +186,7 @@ pub fn generate_parameters<E, C>(
     // Input constraints to ensure full density of IC query
     // x * 0 = 0
     for i in 0..assembly.num_inputs {
-        assembly.enforce(|| "",
-            |lc| lc + Variable(Index::Input(i)),
-            |lc| lc,
-            |lc| lc,
-        );
+        assembly.enforce(|| "", |lc| lc + Variable(Index::Input(i)), |lc| lc, |lc| lc);
     }
 
     // Create bases for blind evaluation of polynomials at tau
@@ -245,10 +224,9 @@ pub fn generate_parameters<E, C>(
         {
             let powers_of_tau = powers_of_tau.as_mut();
             worker.scope(powers_of_tau.len(), |scope, chunk| {
-                for (i, powers_of_tau) in powers_of_tau.chunks_mut(chunk).enumerate()
-                {
+                for (i, powers_of_tau) in powers_of_tau.chunks_mut(chunk).enumerate() {
                     scope.spawn(move || {
-                        let mut current_tau_power = tau.pow(&[(i*chunk) as u64]);
+                        let mut current_tau_power = tau.pow(&[(i * chunk) as u64]);
 
                         for p in powers_of_tau {
                             p.0 = current_tau_power;
@@ -265,14 +243,15 @@ pub fn generate_parameters<E, C>(
 
         // Compute the H query with multiple threads
         worker.scope(h.len(), |scope, chunk| {
-            for (h, p) in h.chunks_mut(chunk).zip(powers_of_tau.as_ref().chunks(chunk))
+            for (h, p) in h
+                .chunks_mut(chunk)
+                .zip(powers_of_tau.as_ref().chunks(chunk))
             {
                 let mut g1_wnaf = g1_wnaf.shared();
 
                 scope.spawn(move || {
                     // Set values of the H query to g1^{(tau^i * t(tau)) / delta}
-                    for (h, p) in h.iter_mut().zip(p.iter())
-                    {
+                    for (h, p) in h.iter_mut().zip(p.iter()) {
                         // Compute final exponent
                         let mut exp = p.0;
                         exp.mul_assign(&coeff);
@@ -325,9 +304,8 @@ pub fn generate_parameters<E, C>(
         beta: &E::Fr,
 
         // Worker
-        worker: &Worker
-    )
-    {
+        worker: &Worker,
+    ) {
         // Sanity check
         assert_eq!(a.len(), at.len());
         assert_eq!(a.len(), bt.len());
@@ -338,31 +316,32 @@ pub fn generate_parameters<E, C>(
 
         // Evaluate polynomials in multiple threads
         worker.scope(a.len(), |scope, chunk| {
-            for ((((((a, b_g1), b_g2), ext), at), bt), ct) in a.chunks_mut(chunk)
-                                                               .zip(b_g1.chunks_mut(chunk))
-                                                               .zip(b_g2.chunks_mut(chunk))
-                                                               .zip(ext.chunks_mut(chunk))
-                                                               .zip(at.chunks(chunk))
-                                                               .zip(bt.chunks(chunk))
-                                                               .zip(ct.chunks(chunk))
+            for ((((((a, b_g1), b_g2), ext), at), bt), ct) in a
+                .chunks_mut(chunk)
+                .zip(b_g1.chunks_mut(chunk))
+                .zip(b_g2.chunks_mut(chunk))
+                .zip(ext.chunks_mut(chunk))
+                .zip(at.chunks(chunk))
+                .zip(bt.chunks(chunk))
+                .zip(ct.chunks(chunk))
             {
                 let mut g1_wnaf = g1_wnaf.shared();
                 let mut g2_wnaf = g2_wnaf.shared();
 
                 scope.spawn(move || {
-                    for ((((((a, b_g1), b_g2), ext), at), bt), ct) in a.iter_mut()
-                                                                       .zip(b_g1.iter_mut())
-                                                                       .zip(b_g2.iter_mut())
-                                                                       .zip(ext.iter_mut())
-                                                                       .zip(at.iter())
-                                                                       .zip(bt.iter())
-                                                                       .zip(ct.iter())
+                    for ((((((a, b_g1), b_g2), ext), at), bt), ct) in a
+                        .iter_mut()
+                        .zip(b_g1.iter_mut())
+                        .zip(b_g2.iter_mut())
+                        .zip(ext.iter_mut())
+                        .zip(at.iter())
+                        .zip(bt.iter())
+                        .zip(ct.iter())
                     {
                         fn eval_at_tau<E: Engine>(
                             powers_of_tau: &[Scalar<E>],
-                            p: &[(E::Fr, usize)]
-                        ) -> E::Fr
-                        {
+                            p: &[(E::Fr, usize)],
+                        ) -> E::Fr {
                             let mut acc = E::Fr::zero();
 
                             for &(ref coeff, index) in p {
@@ -427,7 +406,7 @@ pub fn generate_parameters<E, C>(
         &gamma_inverse,
         &alpha,
         &beta,
-        &worker
+        &worker,
     );
 
     // Evaluate for auxillary variables.
@@ -445,7 +424,7 @@ pub fn generate_parameters<E, C>(
         &delta_inverse,
         &alpha,
         &beta,
-        &worker
+        &worker,
     );
 
     // Don't allow any elements be unconstrained, so that
@@ -466,7 +445,7 @@ pub fn generate_parameters<E, C>(
         gamma_g2: g2.mul(gamma).into_affine(),
         delta_g1: g1.mul(delta).into_affine(),
         delta_g2: g2.mul(delta).into_affine(),
-        ic: ic.into_iter().map(|e| e.into_affine()).collect()
+        ic: ic.into_iter().map(|e| e.into_affine()).collect(),
     };
 
     Ok(Parameters {
@@ -475,8 +454,23 @@ pub fn generate_parameters<E, C>(
         l: Arc::new(l.into_iter().map(|e| e.into_affine()).collect()),
 
         // Filter points at infinity away from A/B queries
-        a: Arc::new(a.into_iter().filter(|e| !e.is_zero()).map(|e| e.into_affine()).collect()),
-        b_g1: Arc::new(b_g1.into_iter().filter(|e| !e.is_zero()).map(|e| e.into_affine()).collect()),
-        b_g2: Arc::new(b_g2.into_iter().filter(|e| !e.is_zero()).map(|e| e.into_affine()).collect())
+        a: Arc::new(
+            a.into_iter()
+                .filter(|e| !e.is_zero())
+                .map(|e| e.into_affine())
+                .collect(),
+        ),
+        b_g1: Arc::new(
+            b_g1.into_iter()
+                .filter(|e| !e.is_zero())
+                .map(|e| e.into_affine())
+                .collect(),
+        ),
+        b_g2: Arc::new(
+            b_g2.into_iter()
+                .filter(|e| !e.is_zero())
+                .map(|e| e.into_affine())
+                .collect(),
+        ),
     })
 }

--- a/src/groth16/mod.rs
+++ b/src/groth16/mod.rs
@@ -1,11 +1,9 @@
-use pairing::{CurveAffine, EncodedPoint, Engine};
-
-use SynthesisError;
-
 use byteorder::{BigEndian, ReadBytesExt, WriteBytesExt};
 use multiexp::SourceBuilder;
+use pairing::{CurveAffine, EncodedPoint, Engine};
 use std::io::{self, Read, Write};
 use std::sync::Arc;
+use SynthesisError;
 
 #[cfg(test)]
 mod tests;

--- a/src/groth16/mod.rs
+++ b/src/groth16/mod.rs
@@ -89,7 +89,7 @@ impl<E: Engine> Proof<E> {
                 }
             })?;
 
-        Ok(Proof { a: a, b: b, c: c })
+        Ok(Proof { a, b, c })
     }
 }
 
@@ -207,13 +207,13 @@ impl<E: Engine> VerifyingKey<E> {
         }
 
         Ok(VerifyingKey {
-            alpha_g1: alpha_g1,
-            beta_g1: beta_g1,
-            beta_g2: beta_g2,
-            gamma_g2: gamma_g2,
-            delta_g1: delta_g1,
-            delta_g2: delta_g2,
-            ic: ic,
+            alpha_g1,
+            beta_g1,
+            beta_g2,
+            gamma_g2,
+            delta_g1,
+            delta_g2,
+            ic,
         })
     }
 }
@@ -373,7 +373,7 @@ impl<E: Engine> Parameters<E> {
         }
 
         Ok(Parameters {
-            vk: vk,
+            vk,
             h: Arc::new(h),
             l: Arc::new(l),
             a: Arc::new(a),

--- a/src/groth16/mod.rs
+++ b/src/groth16/mod.rs
@@ -1,17 +1,11 @@
-use pairing::{
-    Engine,
-    CurveAffine,
-    EncodedPoint
-};
+use pairing::{CurveAffine, EncodedPoint, Engine};
 
-use ::{
-    SynthesisError
-};
+use SynthesisError;
 
+use byteorder::{BigEndian, ReadBytesExt, WriteBytesExt};
 use multiexp::SourceBuilder;
 use std::io::{self, Read, Write};
 use std::sync::Arc;
-use byteorder::{BigEndian, WriteBytesExt, ReadBytesExt};
 
 #[cfg(test)]
 mod tests;
@@ -28,23 +22,17 @@ pub use self::verifier::*;
 pub struct Proof<E: Engine> {
     pub a: E::G1Affine,
     pub b: E::G2Affine,
-    pub c: E::G1Affine
+    pub c: E::G1Affine,
 }
 
 impl<E: Engine> PartialEq for Proof<E> {
     fn eq(&self, other: &Self) -> bool {
-        self.a == other.a &&
-        self.b == other.b &&
-        self.c == other.c
+        self.a == other.a && self.b == other.b && self.c == other.c
     }
 }
 
 impl<E: Engine> Proof<E> {
-    pub fn write<W: Write>(
-        &self,
-        mut writer: W
-    ) -> io::Result<()>
-    {
+    pub fn write<W: Write>(&self, mut writer: W) -> io::Result<()> {
         writer.write_all(self.a.into_compressed().as_ref())?;
         writer.write_all(self.b.into_compressed().as_ref())?;
         writer.write_all(self.c.into_compressed().as_ref())?;
@@ -52,48 +40,56 @@ impl<E: Engine> Proof<E> {
         Ok(())
     }
 
-    pub fn read<R: Read>(
-        mut reader: R
-    ) -> io::Result<Self>
-    {
+    pub fn read<R: Read>(mut reader: R) -> io::Result<Self> {
         let mut g1_repr = <E::G1Affine as CurveAffine>::Compressed::empty();
         let mut g2_repr = <E::G2Affine as CurveAffine>::Compressed::empty();
 
         reader.read_exact(g1_repr.as_mut())?;
         let a = g1_repr
-                .into_affine()
-                .map_err(|e| io::Error::new(io::ErrorKind::InvalidData, e))
-                .and_then(|e| if e.is_zero() {
-                    Err(io::Error::new(io::ErrorKind::InvalidData, "point at infinity"))
+            .into_affine()
+            .map_err(|e| io::Error::new(io::ErrorKind::InvalidData, e))
+            .and_then(|e| {
+                if e.is_zero() {
+                    Err(io::Error::new(
+                        io::ErrorKind::InvalidData,
+                        "point at infinity",
+                    ))
                 } else {
                     Ok(e)
-                })?;
+                }
+            })?;
 
         reader.read_exact(g2_repr.as_mut())?;
         let b = g2_repr
-                .into_affine()
-                .map_err(|e| io::Error::new(io::ErrorKind::InvalidData, e))
-                .and_then(|e| if e.is_zero() {
-                    Err(io::Error::new(io::ErrorKind::InvalidData, "point at infinity"))
+            .into_affine()
+            .map_err(|e| io::Error::new(io::ErrorKind::InvalidData, e))
+            .and_then(|e| {
+                if e.is_zero() {
+                    Err(io::Error::new(
+                        io::ErrorKind::InvalidData,
+                        "point at infinity",
+                    ))
                 } else {
                     Ok(e)
-                })?;
+                }
+            })?;
 
         reader.read_exact(g1_repr.as_mut())?;
         let c = g1_repr
-                .into_affine()
-                .map_err(|e| io::Error::new(io::ErrorKind::InvalidData, e))
-                .and_then(|e| if e.is_zero() {
-                    Err(io::Error::new(io::ErrorKind::InvalidData, "point at infinity"))
+            .into_affine()
+            .map_err(|e| io::Error::new(io::ErrorKind::InvalidData, e))
+            .and_then(|e| {
+                if e.is_zero() {
+                    Err(io::Error::new(
+                        io::ErrorKind::InvalidData,
+                        "point at infinity",
+                    ))
                 } else {
                     Ok(e)
-                })?;
+                }
+            })?;
 
-        Ok(Proof {
-            a: a,
-            b: b,
-            c: c
-        })
+        Ok(Proof { a: a, b: b, c: c })
     }
 }
 
@@ -122,27 +118,23 @@ pub struct VerifyingKey<E: Engine> {
     // for all public inputs. Because all public inputs have a dummy constraint,
     // this is the same size as the number of inputs, and never contains points
     // at infinity.
-    pub ic: Vec<E::G1Affine>
+    pub ic: Vec<E::G1Affine>,
 }
 
 impl<E: Engine> PartialEq for VerifyingKey<E> {
     fn eq(&self, other: &Self) -> bool {
-        self.alpha_g1 == other.alpha_g1 &&
-        self.beta_g1 == other.beta_g1 &&
-        self.beta_g2 == other.beta_g2 &&
-        self.gamma_g2 == other.gamma_g2 &&
-        self.delta_g1 == other.delta_g1 &&
-        self.delta_g2 == other.delta_g2 &&
-        self.ic == other.ic
+        self.alpha_g1 == other.alpha_g1
+            && self.beta_g1 == other.beta_g1
+            && self.beta_g2 == other.beta_g2
+            && self.gamma_g2 == other.gamma_g2
+            && self.delta_g1 == other.delta_g1
+            && self.delta_g2 == other.delta_g2
+            && self.ic == other.ic
     }
 }
 
 impl<E: Engine> VerifyingKey<E> {
-    pub fn write<W: Write>(
-        &self,
-        mut writer: W
-    ) -> io::Result<()>
-    {
+    pub fn write<W: Write>(&self, mut writer: W) -> io::Result<()> {
         writer.write_all(self.alpha_g1.into_uncompressed().as_ref())?;
         writer.write_all(self.beta_g1.into_uncompressed().as_ref())?;
         writer.write_all(self.beta_g2.into_uncompressed().as_ref())?;
@@ -157,30 +149,39 @@ impl<E: Engine> VerifyingKey<E> {
         Ok(())
     }
 
-    pub fn read<R: Read>(
-        mut reader: R
-    ) -> io::Result<Self>
-    {
+    pub fn read<R: Read>(mut reader: R) -> io::Result<Self> {
         let mut g1_repr = <E::G1Affine as CurveAffine>::Uncompressed::empty();
         let mut g2_repr = <E::G2Affine as CurveAffine>::Uncompressed::empty();
 
         reader.read_exact(g1_repr.as_mut())?;
-        let alpha_g1 = g1_repr.into_affine().map_err(|e| io::Error::new(io::ErrorKind::InvalidData, e))?;
+        let alpha_g1 = g1_repr
+            .into_affine()
+            .map_err(|e| io::Error::new(io::ErrorKind::InvalidData, e))?;
 
         reader.read_exact(g1_repr.as_mut())?;
-        let beta_g1 = g1_repr.into_affine().map_err(|e| io::Error::new(io::ErrorKind::InvalidData, e))?;
+        let beta_g1 = g1_repr
+            .into_affine()
+            .map_err(|e| io::Error::new(io::ErrorKind::InvalidData, e))?;
 
         reader.read_exact(g2_repr.as_mut())?;
-        let beta_g2 = g2_repr.into_affine().map_err(|e| io::Error::new(io::ErrorKind::InvalidData, e))?;
+        let beta_g2 = g2_repr
+            .into_affine()
+            .map_err(|e| io::Error::new(io::ErrorKind::InvalidData, e))?;
 
         reader.read_exact(g2_repr.as_mut())?;
-        let gamma_g2 = g2_repr.into_affine().map_err(|e| io::Error::new(io::ErrorKind::InvalidData, e))?;
+        let gamma_g2 = g2_repr
+            .into_affine()
+            .map_err(|e| io::Error::new(io::ErrorKind::InvalidData, e))?;
 
         reader.read_exact(g1_repr.as_mut())?;
-        let delta_g1 = g1_repr.into_affine().map_err(|e| io::Error::new(io::ErrorKind::InvalidData, e))?;
+        let delta_g1 = g1_repr
+            .into_affine()
+            .map_err(|e| io::Error::new(io::ErrorKind::InvalidData, e))?;
 
         reader.read_exact(g2_repr.as_mut())?;
-        let delta_g2 = g2_repr.into_affine().map_err(|e| io::Error::new(io::ErrorKind::InvalidData, e))?;
+        let delta_g2 = g2_repr
+            .into_affine()
+            .map_err(|e| io::Error::new(io::ErrorKind::InvalidData, e))?;
 
         let ic_len = reader.read_u32::<BigEndian>()? as usize;
 
@@ -189,13 +190,18 @@ impl<E: Engine> VerifyingKey<E> {
         for _ in 0..ic_len {
             reader.read_exact(g1_repr.as_mut())?;
             let g1 = g1_repr
-                     .into_affine()
-                     .map_err(|e| io::Error::new(io::ErrorKind::InvalidData, e))
-                     .and_then(|e| if e.is_zero() {
-                         Err(io::Error::new(io::ErrorKind::InvalidData, "point at infinity"))
-                     } else {
-                         Ok(e)
-                     })?;
+                .into_affine()
+                .map_err(|e| io::Error::new(io::ErrorKind::InvalidData, e))
+                .and_then(|e| {
+                    if e.is_zero() {
+                        Err(io::Error::new(
+                            io::ErrorKind::InvalidData,
+                            "point at infinity",
+                        ))
+                    } else {
+                        Ok(e)
+                    }
+                })?;
 
             ic.push(g1);
         }
@@ -207,7 +213,7 @@ impl<E: Engine> VerifyingKey<E> {
             gamma_g2: gamma_g2,
             delta_g1: delta_g1,
             delta_g2: delta_g2,
-            ic: ic
+            ic: ic,
         })
     }
 }
@@ -216,7 +222,7 @@ impl<E: Engine> VerifyingKey<E> {
 pub struct Parameters<E: Engine> {
     pub vk: VerifyingKey<E>,
 
-    // Elements of the form ((tau^i * t(tau)) / delta) for i between 0 and 
+    // Elements of the form ((tau^i * t(tau)) / delta) for i between 0 and
     // m-2 inclusive. Never contains points at infinity.
     pub h: Arc<Vec<E::G1Affine>>,
 
@@ -234,26 +240,22 @@ pub struct Parameters<E: Engine> {
     // G1 and G2 for C/B queries, respectively. Never contains points at
     // infinity for the same reason as the "A" polynomials.
     pub b_g1: Arc<Vec<E::G1Affine>>,
-    pub b_g2: Arc<Vec<E::G2Affine>>
+    pub b_g2: Arc<Vec<E::G2Affine>>,
 }
 
 impl<E: Engine> PartialEq for Parameters<E> {
     fn eq(&self, other: &Self) -> bool {
-        self.vk == other.vk &&
-        self.h == other.h &&
-        self.l == other.l &&
-        self.a == other.a &&
-        self.b_g1 == other.b_g1 &&
-        self.b_g2 == other.b_g2
+        self.vk == other.vk
+            && self.h == other.h
+            && self.l == other.l
+            && self.a == other.a
+            && self.b_g1 == other.b_g1
+            && self.b_g2 == other.b_g2
     }
 }
 
 impl<E: Engine> Parameters<E> {
-    pub fn write<W: Write>(
-        &self,
-        mut writer: W
-    ) -> io::Result<()>
-    {
+    pub fn write<W: Write>(&self, mut writer: W) -> io::Result<()> {
         self.vk.write(&mut writer)?;
 
         writer.write_u32::<BigEndian>(self.h.len() as u32)?;
@@ -284,28 +286,26 @@ impl<E: Engine> Parameters<E> {
         Ok(())
     }
 
-    pub fn read<R: Read>(
-        mut reader: R,
-        checked: bool
-    ) -> io::Result<Self>
-    {
+    pub fn read<R: Read>(mut reader: R, checked: bool) -> io::Result<Self> {
         let read_g1 = |reader: &mut R| -> io::Result<E::G1Affine> {
             let mut repr = <E::G1Affine as CurveAffine>::Uncompressed::empty();
             reader.read_exact(repr.as_mut())?;
 
             if checked {
-                repr
-                .into_affine()
+                repr.into_affine()
             } else {
-                repr
-                .into_affine_unchecked()
-            }
-            .map_err(|e| io::Error::new(io::ErrorKind::InvalidData, e))
-            .and_then(|e| if e.is_zero() {
-                Err(io::Error::new(io::ErrorKind::InvalidData, "point at infinity"))
-            } else {
-                Ok(e)
-            })
+                repr.into_affine_unchecked()
+            }.map_err(|e| io::Error::new(io::ErrorKind::InvalidData, e))
+                .and_then(|e| {
+                    if e.is_zero() {
+                        Err(io::Error::new(
+                            io::ErrorKind::InvalidData,
+                            "point at infinity",
+                        ))
+                    } else {
+                        Ok(e)
+                    }
+                })
         };
 
         let read_g2 = |reader: &mut R| -> io::Result<E::G2Affine> {
@@ -313,18 +313,20 @@ impl<E: Engine> Parameters<E> {
             reader.read_exact(repr.as_mut())?;
 
             if checked {
-                repr
-                .into_affine()
+                repr.into_affine()
             } else {
-                repr
-                .into_affine_unchecked()
-            }
-            .map_err(|e| io::Error::new(io::ErrorKind::InvalidData, e))
-            .and_then(|e| if e.is_zero() {
-                Err(io::Error::new(io::ErrorKind::InvalidData, "point at infinity"))
-            } else {
-                Ok(e)
-            })
+                repr.into_affine_unchecked()
+            }.map_err(|e| io::Error::new(io::ErrorKind::InvalidData, e))
+                .and_then(|e| {
+                    if e.is_zero() {
+                        Err(io::Error::new(
+                            io::ErrorKind::InvalidData,
+                            "point at infinity",
+                        ))
+                    } else {
+                        Ok(e)
+                    }
+                })
         };
 
         let vk = VerifyingKey::<E>::read(&mut reader)?;
@@ -376,7 +378,7 @@ impl<E: Engine> Parameters<E> {
             l: Arc::new(l),
             a: Arc::new(a),
             b_g1: Arc::new(b_g1),
-            b_g2: Arc::new(b_g2)
+            b_g2: Arc::new(b_g2),
         })
     }
 }
@@ -389,39 +391,30 @@ pub struct PreparedVerifyingKey<E: Engine> {
     /// -delta in G2
     neg_delta_g2: <E::G2Affine as CurveAffine>::Prepared,
     /// Copy of IC from `VerifiyingKey`.
-    ic: Vec<E::G1Affine>
+    ic: Vec<E::G1Affine>,
 }
 
 pub trait ParameterSource<E: Engine> {
     type G1Builder: SourceBuilder<E::G1Affine>;
     type G2Builder: SourceBuilder<E::G2Affine>;
 
-    fn get_vk(
-        &mut self,
-        num_ic: usize
-    ) -> Result<VerifyingKey<E>, SynthesisError>;
-    fn get_h(
-        &mut self,
-        num_h: usize
-    ) -> Result<Self::G1Builder, SynthesisError>;
-    fn get_l(
-        &mut self,
-        num_l: usize
-    ) -> Result<Self::G1Builder, SynthesisError>;
+    fn get_vk(&mut self, num_ic: usize) -> Result<VerifyingKey<E>, SynthesisError>;
+    fn get_h(&mut self, num_h: usize) -> Result<Self::G1Builder, SynthesisError>;
+    fn get_l(&mut self, num_l: usize) -> Result<Self::G1Builder, SynthesisError>;
     fn get_a(
         &mut self,
         num_inputs: usize,
-        num_aux: usize
+        num_aux: usize,
     ) -> Result<(Self::G1Builder, Self::G1Builder), SynthesisError>;
     fn get_b_g1(
         &mut self,
         num_inputs: usize,
-        num_aux: usize
+        num_aux: usize,
     ) -> Result<(Self::G1Builder, Self::G1Builder), SynthesisError>;
     fn get_b_g2(
         &mut self,
         num_inputs: usize,
-        num_aux: usize
+        num_aux: usize,
     ) -> Result<(Self::G2Builder, Self::G2Builder), SynthesisError>;
 }
 
@@ -429,54 +422,39 @@ impl<'a, E: Engine> ParameterSource<E> for &'a Parameters<E> {
     type G1Builder = (Arc<Vec<E::G1Affine>>, usize);
     type G2Builder = (Arc<Vec<E::G2Affine>>, usize);
 
-    fn get_vk(
-        &mut self,
-        _: usize
-    ) -> Result<VerifyingKey<E>, SynthesisError>
-    {
+    fn get_vk(&mut self, _: usize) -> Result<VerifyingKey<E>, SynthesisError> {
         Ok(self.vk.clone())
     }
 
-    fn get_h(
-        &mut self,
-        _: usize
-    ) -> Result<Self::G1Builder, SynthesisError>
-    {
+    fn get_h(&mut self, _: usize) -> Result<Self::G1Builder, SynthesisError> {
         Ok((self.h.clone(), 0))
     }
 
-    fn get_l(
-        &mut self,
-        _: usize
-    ) -> Result<Self::G1Builder, SynthesisError>
-    {
+    fn get_l(&mut self, _: usize) -> Result<Self::G1Builder, SynthesisError> {
         Ok((self.l.clone(), 0))
     }
 
     fn get_a(
         &mut self,
         num_inputs: usize,
-        _: usize
-    ) -> Result<(Self::G1Builder, Self::G1Builder), SynthesisError>
-    {
+        _: usize,
+    ) -> Result<(Self::G1Builder, Self::G1Builder), SynthesisError> {
         Ok(((self.a.clone(), 0), (self.a.clone(), num_inputs)))
     }
 
     fn get_b_g1(
         &mut self,
         num_inputs: usize,
-        _: usize
-    ) -> Result<(Self::G1Builder, Self::G1Builder), SynthesisError>
-    {
+        _: usize,
+    ) -> Result<(Self::G1Builder, Self::G1Builder), SynthesisError> {
         Ok(((self.b_g1.clone(), 0), (self.b_g1.clone(), num_inputs)))
     }
 
     fn get_b_g2(
         &mut self,
         num_inputs: usize,
-        _: usize
-    ) -> Result<(Self::G2Builder, Self::G2Builder), SynthesisError>
-    {
+        _: usize,
+    ) -> Result<(Self::G2Builder, Self::G2Builder), SynthesisError> {
         Ok(((self.b_g2.clone(), 0), (self.b_g2.clone(), num_inputs)))
     }
 }
@@ -484,41 +462,38 @@ impl<'a, E: Engine> ParameterSource<E> for &'a Parameters<E> {
 #[cfg(test)]
 mod test_with_bls12_381 {
     use super::*;
-    use {Circuit, SynthesisError, ConstraintSystem};
+    use {Circuit, ConstraintSystem, SynthesisError};
 
-    use rand::{Rand, thread_rng};
-    use pairing::{Field};
     use pairing::bls12_381::{Bls12, Fr};
+    use pairing::Field;
+    use rand::{thread_rng, Rand};
 
     #[test]
     fn serialization() {
         struct MySillyCircuit<E: Engine> {
             a: Option<E::Fr>,
-            b: Option<E::Fr>
+            b: Option<E::Fr>,
         }
 
         impl<E: Engine> Circuit<E> for MySillyCircuit<E> {
             fn synthesize<CS: ConstraintSystem<E>>(
                 self,
-                cs: &mut CS
-            ) -> Result<(), SynthesisError>
-            {
+                cs: &mut CS,
+            ) -> Result<(), SynthesisError> {
                 let a = cs.alloc(|| "a", || self.a.ok_or(SynthesisError::AssignmentMissing))?;
                 let b = cs.alloc(|| "b", || self.b.ok_or(SynthesisError::AssignmentMissing))?;
-                let c = cs.alloc_input(|| "c", || {
-                    let mut a = self.a.ok_or(SynthesisError::AssignmentMissing)?;
-                    let b = self.b.ok_or(SynthesisError::AssignmentMissing)?;
+                let c = cs.alloc_input(
+                    || "c",
+                    || {
+                        let mut a = self.a.ok_or(SynthesisError::AssignmentMissing)?;
+                        let b = self.b.ok_or(SynthesisError::AssignmentMissing)?;
 
-                    a.mul_assign(&b);
-                    Ok(a)
-                })?;
+                        a.mul_assign(&b);
+                        Ok(a)
+                    },
+                )?;
 
-                cs.enforce(
-                    || "a*b=c",
-                    |lc| lc + a,
-                    |lc| lc + b,
-                    |lc| lc + c
-                );
+                cs.enforce(|| "a*b=c", |lc| lc + a, |lc| lc + b, |lc| lc + c);
 
                 Ok(())
             }
@@ -526,10 +501,9 @@ mod test_with_bls12_381 {
 
         let rng = &mut thread_rng();
 
-        let params = generate_random_parameters::<Bls12, _, _>(
-            MySillyCircuit { a: None, b: None },
-            rng
-        ).unwrap();
+        let params =
+            generate_random_parameters::<Bls12, _, _>(MySillyCircuit { a: None, b: None }, rng)
+                .unwrap();
 
         {
             let mut v = vec![];
@@ -555,10 +529,10 @@ mod test_with_bls12_381 {
             let proof = create_random_proof(
                 MySillyCircuit {
                     a: Some(a),
-                    b: Some(b)
+                    b: Some(b),
                 },
                 &params,
-                rng
+                rng,
             ).unwrap();
 
             let mut v = vec![];

--- a/src/groth16/prover.rs
+++ b/src/groth16/prover.rs
@@ -1,20 +1,12 @@
-use rand::Rng;
-
-use std::sync::Arc;
-
-use futures::Future;
-
-use pairing::{CurveAffine, CurveProjective, Engine, Field, PrimeField};
-
 use super::{ParameterSource, Proof};
-
-use {Circuit, ConstraintSystem, Index, LinearCombination, SynthesisError, Variable};
-
 use domain::{EvaluationDomain, Scalar};
-
-use multiexp::{multiexp, DensityTracker, FullDensity};
-
+use futures::Future;
 use multicore::Worker;
+use multiexp::{multiexp, DensityTracker, FullDensity};
+use pairing::{CurveAffine, CurveProjective, Engine, Field, PrimeField};
+use rand::Rng;
+use std::sync::Arc;
+use {Circuit, ConstraintSystem, Index, LinearCombination, SynthesisError, Variable};
 
 fn eval<E: Engine>(
     lc: &LinearCombination<E>,

--- a/src/groth16/prover.rs
+++ b/src/groth16/prover.rs
@@ -25,7 +25,7 @@ fn eval<E: Engine>(
 ) -> E::Fr {
     let mut acc = E::Fr::zero();
 
-    for &(index, coeff) in lc.0.iter() {
+    for &(index, coeff) in &lc.0 {
         let mut tmp;
 
         match index {
@@ -173,6 +173,7 @@ where
     create_proof::<E, C, P>(circuit, params, r, s)
 }
 
+#[cfg_attr(feature = "cargo-clippy", allow(many_single_char_names))]
 pub fn create_proof<E, C, P: ParameterSource<E>>(
     circuit: C,
     mut params: P,

--- a/src/groth16/prover.rs
+++ b/src/groth16/prover.rs
@@ -4,51 +4,25 @@ use std::sync::Arc;
 
 use futures::Future;
 
-use pairing::{
-    Engine,
-    PrimeField,
-    Field,
-    CurveProjective,
-    CurveAffine
-};
+use pairing::{CurveAffine, CurveProjective, Engine, Field, PrimeField};
 
-use super::{
-    ParameterSource,
-    Proof
-};
+use super::{ParameterSource, Proof};
 
-use ::{
-    SynthesisError,
-    Circuit,
-    ConstraintSystem,
-    LinearCombination,
-    Variable,
-    Index
-};
+use {Circuit, ConstraintSystem, Index, LinearCombination, SynthesisError, Variable};
 
-use ::domain::{
-    EvaluationDomain,
-    Scalar
-};
+use domain::{EvaluationDomain, Scalar};
 
-use ::multiexp::{
-    DensityTracker,
-    FullDensity,
-    multiexp
-};
+use multiexp::{multiexp, DensityTracker, FullDensity};
 
-use ::multicore::{
-    Worker
-};
+use multicore::Worker;
 
 fn eval<E: Engine>(
     lc: &LinearCombination<E>,
     mut input_density: Option<&mut DensityTracker>,
     mut aux_density: Option<&mut DensityTracker>,
     input_assignment: &[E::Fr],
-    aux_assignment: &[E::Fr]
-) -> E::Fr
-{
+    aux_assignment: &[E::Fr],
+) -> E::Fr {
     let mut acc = E::Fr::zero();
 
     for &(index, coeff) in lc.0.iter() {
@@ -60,7 +34,7 @@ fn eval<E: Engine>(
                 if let Some(ref mut v) = input_density {
                     v.inc(i);
                 }
-            },
+            }
             Variable(Index::Aux(i)) => {
                 tmp = aux_assignment[i];
                 if let Some(ref mut v) = aux_density {
@@ -70,10 +44,10 @@ fn eval<E: Engine>(
         }
 
         if coeff == E::Fr::one() {
-           acc.add_assign(&tmp);
+            acc.add_assign(&tmp);
         } else {
-           tmp.mul_assign(&coeff);
-           acc.add_assign(&tmp);
+            tmp.mul_assign(&coeff);
+            acc.add_assign(&tmp);
         }
     }
 
@@ -93,18 +67,17 @@ struct ProvingAssignment<E: Engine> {
 
     // Assignments of variables
     input_assignment: Vec<E::Fr>,
-    aux_assignment: Vec<E::Fr>
+    aux_assignment: Vec<E::Fr>,
 }
 
 impl<E: Engine> ConstraintSystem<E> for ProvingAssignment<E> {
     type Root = Self;
 
-    fn alloc<F, A, AR>(
-        &mut self,
-        _: A,
-        f: F
-    ) -> Result<Variable, SynthesisError>
-        where F: FnOnce() -> Result<E::Fr, SynthesisError>, A: FnOnce() -> AR, AR: Into<String>
+    fn alloc<F, A, AR>(&mut self, _: A, f: F) -> Result<Variable, SynthesisError>
+    where
+        F: FnOnce() -> Result<E::Fr, SynthesisError>,
+        A: FnOnce() -> AR,
+        AR: Into<String>,
     {
         self.aux_assignment.push(f()?);
         self.a_aux_density.add_element();
@@ -113,12 +86,11 @@ impl<E: Engine> ConstraintSystem<E> for ProvingAssignment<E> {
         Ok(Variable(Index::Aux(self.aux_assignment.len() - 1)))
     }
 
-    fn alloc_input<F, A, AR>(
-        &mut self,
-        _: A,
-        f: F
-    ) -> Result<Variable, SynthesisError>
-        where F: FnOnce() -> Result<E::Fr, SynthesisError>, A: FnOnce() -> AR, AR: Into<String>
+    fn alloc_input<F, A, AR>(&mut self, _: A, f: F) -> Result<Variable, SynthesisError>
+    where
+        F: FnOnce() -> Result<E::Fr, SynthesisError>,
+        A: FnOnce() -> AR,
+        AR: Into<String>,
     {
         self.input_assignment.push(f()?);
         self.b_input_density.add_element();
@@ -126,17 +98,13 @@ impl<E: Engine> ConstraintSystem<E> for ProvingAssignment<E> {
         Ok(Variable(Index::Input(self.input_assignment.len() - 1)))
     }
 
-    fn enforce<A, AR, LA, LB, LC>(
-        &mut self,
-        _: A,
-        a: LA,
-        b: LB,
-        c: LC
-    )
-        where A: FnOnce() -> AR, AR: Into<String>,
-              LA: FnOnce(LinearCombination<E>) -> LinearCombination<E>,
-              LB: FnOnce(LinearCombination<E>) -> LinearCombination<E>,
-              LC: FnOnce(LinearCombination<E>) -> LinearCombination<E>
+    fn enforce<A, AR, LA, LB, LC>(&mut self, _: A, a: LA, b: LB, c: LC)
+    where
+        A: FnOnce() -> AR,
+        AR: Into<String>,
+        LA: FnOnce(LinearCombination<E>) -> LinearCombination<E>,
+        LB: FnOnce(LinearCombination<E>) -> LinearCombination<E>,
+        LC: FnOnce(LinearCombination<E>) -> LinearCombination<E>,
     {
         let a = a(LinearCombination::zero());
         let b = b(LinearCombination::zero());
@@ -150,14 +118,14 @@ impl<E: Engine> ConstraintSystem<E> for ProvingAssignment<E> {
             None,
             Some(&mut self.a_aux_density),
             &self.input_assignment,
-            &self.aux_assignment
+            &self.aux_assignment,
         )));
         self.b.push(Scalar(eval(
             &b,
             Some(&mut self.b_input_density),
             Some(&mut self.b_aux_density),
             &self.input_assignment,
-            &self.aux_assignment
+            &self.aux_assignment,
         )));
         self.c.push(Scalar(eval(
             &c,
@@ -168,18 +136,19 @@ impl<E: Engine> ConstraintSystem<E> for ProvingAssignment<E> {
             None,
             None,
             &self.input_assignment,
-            &self.aux_assignment
+            &self.aux_assignment,
         )));
     }
 
     fn push_namespace<NR, N>(&mut self, _: N)
-        where NR: Into<String>, N: FnOnce() -> NR
+    where
+        NR: Into<String>,
+        N: FnOnce() -> NR,
     {
         // Do nothing; we don't care about namespaces in this context.
     }
 
-    fn pop_namespace(&mut self)
-    {
+    fn pop_namespace(&mut self) {
         // Do nothing; we don't care about namespaces in this context.
     }
 
@@ -191,9 +160,12 @@ impl<E: Engine> ConstraintSystem<E> for ProvingAssignment<E> {
 pub fn create_random_proof<E, C, R, P: ParameterSource<E>>(
     circuit: C,
     params: P,
-    rng: &mut R
+    rng: &mut R,
 ) -> Result<Proof<E>, SynthesisError>
-    where E: Engine, C: Circuit<E>, R: Rng
+where
+    E: Engine,
+    C: Circuit<E>,
+    R: Rng,
 {
     let r = rng.gen();
     let s = rng.gen();
@@ -205,9 +177,11 @@ pub fn create_proof<E, C, P: ParameterSource<E>>(
     circuit: C,
     mut params: P,
     r: E::Fr,
-    s: E::Fr
+    s: E::Fr,
 ) -> Result<Proof<E>, SynthesisError>
-    where E: Engine, C: Circuit<E>
+where
+    E: Engine,
+    C: Circuit<E>,
 {
     let mut prover = ProvingAssignment {
         a_aux_density: DensityTracker::new(),
@@ -217,7 +191,7 @@ pub fn create_proof<E, C, P: ParameterSource<E>>(
         b: vec![],
         c: vec![],
         input_assignment: vec![],
-        aux_assignment: vec![]
+        aux_assignment: vec![],
     };
 
     prover.alloc_input(|| "", || Ok(E::Fr::one()))?;
@@ -225,11 +199,7 @@ pub fn create_proof<E, C, P: ParameterSource<E>>(
     circuit.synthesize(&mut prover)?;
 
     for i in 0..prover.input_assignment.len() {
-        prover.enforce(|| "",
-            |lc| lc + Variable(Index::Input(i)),
-            |lc| lc,
-            |lc| lc,
-        );
+        prover.enforce(|| "", |lc| lc + Variable(Index::Input(i)), |lc| lc, |lc| lc);
     }
 
     let worker = Worker::new();
@@ -263,31 +233,76 @@ pub fn create_proof<E, C, P: ParameterSource<E>>(
     };
 
     // TODO: parallelize if it's even helpful
-    let input_assignment = Arc::new(prover.input_assignment.into_iter().map(|s| s.into_repr()).collect::<Vec<_>>());
-    let aux_assignment = Arc::new(prover.aux_assignment.into_iter().map(|s| s.into_repr()).collect::<Vec<_>>());
+    let input_assignment = Arc::new(
+        prover
+            .input_assignment
+            .into_iter()
+            .map(|s| s.into_repr())
+            .collect::<Vec<_>>(),
+    );
+    let aux_assignment = Arc::new(
+        prover
+            .aux_assignment
+            .into_iter()
+            .map(|s| s.into_repr())
+            .collect::<Vec<_>>(),
+    );
 
-    let l = multiexp(&worker, params.get_l(aux_assignment.len())?, FullDensity, aux_assignment.clone());
+    let l = multiexp(
+        &worker,
+        params.get_l(aux_assignment.len())?,
+        FullDensity,
+        aux_assignment.clone(),
+    );
 
     let a_aux_density_total = prover.a_aux_density.get_total_density();
 
-    let (a_inputs_source, a_aux_source) = params.get_a(input_assignment.len(), a_aux_density_total)?;
+    let (a_inputs_source, a_aux_source) =
+        params.get_a(input_assignment.len(), a_aux_density_total)?;
 
-    let a_inputs = multiexp(&worker, a_inputs_source, FullDensity, input_assignment.clone());
-    let a_aux = multiexp(&worker, a_aux_source, Arc::new(prover.a_aux_density), aux_assignment.clone());
+    let a_inputs = multiexp(
+        &worker,
+        a_inputs_source,
+        FullDensity,
+        input_assignment.clone(),
+    );
+    let a_aux = multiexp(
+        &worker,
+        a_aux_source,
+        Arc::new(prover.a_aux_density),
+        aux_assignment.clone(),
+    );
 
     let b_input_density = Arc::new(prover.b_input_density);
     let b_input_density_total = b_input_density.get_total_density();
     let b_aux_density = Arc::new(prover.b_aux_density);
     let b_aux_density_total = b_aux_density.get_total_density();
 
-    let (b_g1_inputs_source, b_g1_aux_source) = params.get_b_g1(b_input_density_total, b_aux_density_total)?;
+    let (b_g1_inputs_source, b_g1_aux_source) =
+        params.get_b_g1(b_input_density_total, b_aux_density_total)?;
 
-    let b_g1_inputs = multiexp(&worker, b_g1_inputs_source, b_input_density.clone(), input_assignment.clone());
-    let b_g1_aux = multiexp(&worker, b_g1_aux_source, b_aux_density.clone(), aux_assignment.clone());
+    let b_g1_inputs = multiexp(
+        &worker,
+        b_g1_inputs_source,
+        b_input_density.clone(),
+        input_assignment.clone(),
+    );
+    let b_g1_aux = multiexp(
+        &worker,
+        b_g1_aux_source,
+        b_aux_density.clone(),
+        aux_assignment.clone(),
+    );
 
-    let (b_g2_inputs_source, b_g2_aux_source) = params.get_b_g2(b_input_density_total, b_aux_density_total)?;
-    
-    let b_g2_inputs = multiexp(&worker, b_g2_inputs_source, b_input_density, input_assignment);
+    let (b_g2_inputs_source, b_g2_aux_source) =
+        params.get_b_g2(b_input_density_total, b_aux_density_total)?;
+
+    let b_g2_inputs = multiexp(
+        &worker,
+        b_g2_inputs_source,
+        b_input_density,
+        input_assignment,
+    );
     let b_g2_aux = multiexp(&worker, b_g2_aux_source, b_aux_density, aux_assignment);
 
     if vk.delta_g1.is_zero() || vk.delta_g2.is_zero() {
@@ -329,6 +344,6 @@ pub fn create_proof<E, C, P: ParameterSource<E>>(
     Ok(Proof {
         a: g_a.into_affine(),
         b: g_b.into_affine(),
-        c: g_c.into_affine()
+        c: g_c.into_affine(),
     })
 }

--- a/src/groth16/tests/dummy_engine.rs
+++ b/src/groth16/tests/dummy_engine.rs
@@ -2,7 +2,6 @@ use pairing::{
     CurveAffine, CurveProjective, EncodedPoint, Engine, Field, GroupDecodingError, LegendreSymbol,
     PrimeField, PrimeFieldDecodingError, PrimeFieldRepr, SqrtField,
 };
-
 use rand::{Rand, Rng};
 use std::cmp::Ordering;
 use std::fmt;

--- a/src/groth16/tests/dummy_engine.rs
+++ b/src/groth16/tests/dummy_engine.rs
@@ -1,20 +1,11 @@
 use pairing::{
-    Engine,
-    PrimeField,
-    PrimeFieldRepr,
-    Field,
-    SqrtField,
-    LegendreSymbol,
-    CurveProjective,
-    CurveAffine,
-    PrimeFieldDecodingError,
-    GroupDecodingError,
-    EncodedPoint
+    CurveAffine, CurveProjective, EncodedPoint, Engine, Field, GroupDecodingError, LegendreSymbol,
+    PrimeField, PrimeFieldDecodingError, PrimeFieldRepr, SqrtField,
 };
 
+use rand::{Rand, Rng};
 use std::cmp::Ordering;
 use std::fmt;
-use rand::{Rand, Rng};
 use std::num::Wrapping;
 
 const MODULUS_R: Wrapping<u32> = Wrapping(64513);
@@ -90,9 +81,13 @@ impl SqrtField for Fr {
     fn legendre(&self) -> LegendreSymbol {
         // s = self^((r - 1) // 2)
         let s = self.pow([32256]);
-        if s == <Fr as Field>::zero() { LegendreSymbol::Zero }
-        else if s == <Fr as Field>::one() { LegendreSymbol::QuadraticResidue }
-        else { LegendreSymbol::QuadraticNonResidue }
+        if s == <Fr as Field>::zero() {
+            LegendreSymbol::Zero
+        } else if s == <Fr as Field>::one() {
+            LegendreSymbol::QuadraticResidue
+        } else {
+            LegendreSymbol::QuadraticNonResidue
+        }
     }
 
     fn sqrt(&self) -> Option<Self> {
@@ -110,7 +105,7 @@ impl SqrtField for Fr {
                 let mut m = Fr::S;
 
                 while t != <Fr as Field>::one() {
-                let mut i = 1;
+                    let mut i = 1;
                     {
                         let mut t2i = t;
                         t2i.square();
@@ -271,15 +266,18 @@ impl Engine for DummyEngine {
     type G2Affine = Fr;
     type Fq = Fr;
     type Fqe = Fr;
-    
+
     // TODO: This should be F_645131 or something. Doesn't matter for now.
     type Fqk = Fr;
 
     fn miller_loop<'a, I>(i: I) -> Self::Fqk
-        where I: IntoIterator<Item=&'a (
-                                    &'a <Self::G1Affine as CurveAffine>::Prepared,
-                                    &'a <Self::G2Affine as CurveAffine>::Prepared
-                               )>
+    where
+        I: IntoIterator<
+            Item = &'a (
+                &'a <Self::G1Affine as CurveAffine>::Prepared,
+                &'a <Self::G2Affine as CurveAffine>::Prepared,
+            ),
+        >,
     {
         let mut acc = <Fr as Field>::zero();
 
@@ -293,8 +291,7 @@ impl Engine for DummyEngine {
     }
 
     /// Perform final exponentiation of the result of a miller loop.
-    fn final_exponentiation(this: &Self::Fqk) -> Option<Self::Fqk>
-    {
+    fn final_exponentiation(this: &Self::Fqk) -> Option<Self::Fqk> {
         Some(*this)
     }
 }
@@ -317,9 +314,7 @@ impl CurveProjective for Fr {
         <Fr as Field>::is_zero(self)
     }
 
-    fn batch_normalization(_: &mut [Self]) {
-        
-    }
+    fn batch_normalization(_: &mut [Self]) {}
 
     fn is_normalized(&self) -> bool {
         true
@@ -341,8 +336,7 @@ impl CurveProjective for Fr {
         <Fr as Field>::negate(self);
     }
 
-    fn mul_assign<S: Into<<Self::Scalar as PrimeField>::Repr>>(&mut self, other: S)
-    {
+    fn mul_assign<S: Into<<Self::Scalar as PrimeField>::Repr>>(&mut self, other: S) {
         let tmp = Fr::from_repr(other.into()).unwrap();
 
         <Fr as Field>::mul_assign(self, &tmp);
@@ -427,8 +421,7 @@ impl CurveAffine for Fr {
         <Fr as Field>::negate(self);
     }
 
-    fn mul<S: Into<<Self::Scalar as PrimeField>::Repr>>(&self, other: S) -> Self::Projective
-    {
+    fn mul<S: Into<<Self::Scalar as PrimeField>::Repr>>(&self, other: S) -> Self::Projective {
         let mut res = *self;
         let tmp = Fr::from_repr(other.into()).unwrap();
 

--- a/src/groth16/tests/mod.rs
+++ b/src/groth16/tests/mod.rs
@@ -1,94 +1,86 @@
-use pairing::{
-    Engine,
-    Field,
-    PrimeField
-};
+use pairing::{Engine, Field, PrimeField};
 
 mod dummy_engine;
 use self::dummy_engine::*;
 
 use std::marker::PhantomData;
 
-use ::{
-    Circuit,
-    ConstraintSystem,
-    SynthesisError
-};
+use {Circuit, ConstraintSystem, SynthesisError};
 
-use super::{
-    generate_parameters,
-    prepare_verifying_key,
-    create_proof,
-    verify_proof
-};
+use super::{create_proof, generate_parameters, prepare_verifying_key, verify_proof};
 
 struct XORDemo<E: Engine> {
     a: Option<bool>,
     b: Option<bool>,
-    _marker: PhantomData<E>
+    _marker: PhantomData<E>,
 }
 
 impl<E: Engine> Circuit<E> for XORDemo<E> {
-    fn synthesize<CS: ConstraintSystem<E>>(
-        self,
-        cs: &mut CS
-    ) -> Result<(), SynthesisError>
-    {
-        let a_var = cs.alloc(|| "a", || {
-            if self.a.is_some() {
-                if self.a.unwrap() {
-                    Ok(E::Fr::one())
+    fn synthesize<CS: ConstraintSystem<E>>(self, cs: &mut CS) -> Result<(), SynthesisError> {
+        let a_var = cs.alloc(
+            || "a",
+            || {
+                if self.a.is_some() {
+                    if self.a.unwrap() {
+                        Ok(E::Fr::one())
+                    } else {
+                        Ok(E::Fr::zero())
+                    }
                 } else {
-                    Ok(E::Fr::zero())
+                    Err(SynthesisError::AssignmentMissing)
                 }
-            } else {
-                Err(SynthesisError::AssignmentMissing)
-            }
-        })?;
+            },
+        )?;
 
         cs.enforce(
             || "a_boolean_constraint",
             |lc| lc + CS::one() - a_var,
             |lc| lc + a_var,
-            |lc| lc
+            |lc| lc,
         );
 
-        let b_var = cs.alloc(|| "b", || {
-            if self.b.is_some() {
-                if self.b.unwrap() {
-                    Ok(E::Fr::one())
+        let b_var = cs.alloc(
+            || "b",
+            || {
+                if self.b.is_some() {
+                    if self.b.unwrap() {
+                        Ok(E::Fr::one())
+                    } else {
+                        Ok(E::Fr::zero())
+                    }
                 } else {
-                    Ok(E::Fr::zero())
+                    Err(SynthesisError::AssignmentMissing)
                 }
-            } else {
-                Err(SynthesisError::AssignmentMissing)
-            }
-        })?;
+            },
+        )?;
 
         cs.enforce(
             || "b_boolean_constraint",
             |lc| lc + CS::one() - b_var,
             |lc| lc + b_var,
-            |lc| lc
+            |lc| lc,
         );
 
-        let c_var = cs.alloc_input(|| "c", || {
-            if self.a.is_some() && self.b.is_some() {
-                if self.a.unwrap() ^ self.b.unwrap() {
-                    Ok(E::Fr::one())
+        let c_var = cs.alloc_input(
+            || "c",
+            || {
+                if self.a.is_some() && self.b.is_some() {
+                    if self.a.unwrap() ^ self.b.unwrap() {
+                        Ok(E::Fr::one())
+                    } else {
+                        Ok(E::Fr::zero())
+                    }
                 } else {
-                    Ok(E::Fr::zero())
+                    Err(SynthesisError::AssignmentMissing)
                 }
-            } else {
-                Err(SynthesisError::AssignmentMissing)
-            }
-        })?;
+            },
+        )?;
 
         cs.enforce(
             || "c_xor_constraint",
             |lc| lc + a_var + a_var,
             |lc| lc + b_var,
-            |lc| lc + a_var + b_var - c_var
+            |lc| lc + a_var + b_var - c_var,
         );
 
         Ok(())
@@ -109,19 +101,10 @@ fn test_xordemo() {
         let c = XORDemo::<DummyEngine> {
             a: None,
             b: None,
-            _marker: PhantomData
+            _marker: PhantomData,
         };
 
-        generate_parameters(
-            c,
-            g1,
-            g2,
-            alpha,
-            beta,
-            gamma,
-            delta,
-            tau
-        ).unwrap()
+        generate_parameters(c, g1, g2, alpha, beta, gamma, delta, tau).unwrap()
     };
 
     // This will synthesize the constraint system:
@@ -229,32 +212,35 @@ fn test_xordemo() {
     59158
     */
 
-    let u_i = [59158, 48317, 21767, 10402].iter().map(|e| {
-        Fr::from_str(&format!("{}", e)).unwrap()
-    }).collect::<Vec<Fr>>();
-    let v_i = [0, 0, 60619, 30791].iter().map(|e| {
-        Fr::from_str(&format!("{}", e)).unwrap()
-    }).collect::<Vec<Fr>>();
-    let w_i = [0, 23320, 41193, 41193].iter().map(|e| {
-        Fr::from_str(&format!("{}", e)).unwrap()
-    }).collect::<Vec<Fr>>();
+    let u_i = [59158, 48317, 21767, 10402]
+        .iter()
+        .map(|e| Fr::from_str(&format!("{}", e)).unwrap())
+        .collect::<Vec<Fr>>();
+    let v_i = [0, 0, 60619, 30791]
+        .iter()
+        .map(|e| Fr::from_str(&format!("{}", e)).unwrap())
+        .collect::<Vec<Fr>>();
+    let w_i = [0, 23320, 41193, 41193]
+        .iter()
+        .map(|e| Fr::from_str(&format!("{}", e)).unwrap())
+        .collect::<Vec<Fr>>();
 
-    for (u, a) in u_i.iter()
-                     .zip(&params.a[..])
-    {
+    for (u, a) in u_i.iter().zip(&params.a[..]) {
         assert_eq!(u, a);
     }
 
-    for (v, b) in v_i.iter()
-                     .filter(|&&e| e != Fr::zero())
-                     .zip(&params.b_g1[..])
+    for (v, b) in v_i
+        .iter()
+        .filter(|&&e| e != Fr::zero())
+        .zip(&params.b_g1[..])
     {
         assert_eq!(v, b);
     }
 
-    for (v, b) in v_i.iter()
-                     .filter(|&&e| e != Fr::zero())
-                     .zip(&params.b_g2[..])
+    for (v, b) in v_i
+        .iter()
+        .filter(|&&e| e != Fr::zero())
+        .zip(&params.b_g2[..])
     {
         assert_eq!(v, b);
     }
@@ -299,15 +285,10 @@ fn test_xordemo() {
         let c = XORDemo {
             a: Some(true),
             b: Some(false),
-            _marker: PhantomData
+            _marker: PhantomData,
         };
 
-        create_proof(
-            c,
-            &params,
-            r,
-            s
-        ).unwrap()
+        create_proof(c, &params, r, s).unwrap()
     };
 
     // A(x) =
@@ -323,7 +304,7 @@ fn test_xordemo() {
         expected_a.add_assign(&u_i[0]); // a_0 = 1
         expected_a.add_assign(&u_i[1]); // a_1 = 1
         expected_a.add_assign(&u_i[2]); // a_2 = 1
-        // a_3 = 0
+                                        // a_3 = 0
         assert_eq!(proof.a, expected_a);
     }
 
@@ -340,7 +321,7 @@ fn test_xordemo() {
         expected_b.add_assign(&v_i[0]); // a_0 = 1
         expected_b.add_assign(&v_i[1]); // a_1 = 1
         expected_b.add_assign(&v_i[2]); // a_2 = 1
-        // a_3 = 0
+                                        // a_3 = 0
         assert_eq!(proof.b, expected_b);
     }
 
@@ -381,7 +362,10 @@ fn test_xordemo() {
         expected_c.add_assign(&params.l[0]);
 
         // H query answer
-        for (i, coeff) in [5040, 11763, 10755, 63633, 128, 9747, 8739].iter().enumerate() {
+        for (i, coeff) in [5040, 11763, 10755, 63633, 128, 9747, 8739]
+            .iter()
+            .enumerate()
+        {
             let coeff = Fr::from_str(&format!("{}", coeff)).unwrap();
 
             let mut tmp = params.h[i];
@@ -392,9 +376,5 @@ fn test_xordemo() {
         assert_eq!(expected_c, proof.c);
     }
 
-    assert!(verify_proof(
-        &pvk,
-        &proof,
-        &[Fr::one()]
-    ).unwrap());
+    assert!(verify_proof(&pvk, &proof, &[Fr::one()]).unwrap());
 }

--- a/src/groth16/tests/mod.rs
+++ b/src/groth16/tests/mod.rs
@@ -1,13 +1,10 @@
-use pairing::{Engine, Field, PrimeField};
-
 mod dummy_engine;
+
 use self::dummy_engine::*;
-
-use std::marker::PhantomData;
-
-use {Circuit, ConstraintSystem, SynthesisError};
-
 use super::{create_proof, generate_parameters, prepare_verifying_key, verify_proof};
+use pairing::{Engine, Field, PrimeField};
+use std::marker::PhantomData;
+use {Circuit, ConstraintSystem, SynthesisError};
 
 struct XORDemo<E: Engine> {
     a: Option<bool>,

--- a/src/groth16/verifier.rs
+++ b/src/groth16/verifier.rs
@@ -1,7 +1,5 @@
-use pairing::{CurveAffine, CurveProjective, Engine, PrimeField};
-
 use super::{PreparedVerifyingKey, Proof, VerifyingKey};
-
+use pairing::{CurveAffine, CurveProjective, Engine, PrimeField};
 use SynthesisError;
 
 pub fn prepare_verifying_key<E: Engine>(vk: &VerifyingKey<E>) -> PreparedVerifyingKey<E> {

--- a/src/groth16/verifier.rs
+++ b/src/groth16/verifier.rs
@@ -1,24 +1,10 @@
-use pairing::{
-    Engine,
-    CurveProjective,
-    CurveAffine,
-    PrimeField
-};
+use pairing::{CurveAffine, CurveProjective, Engine, PrimeField};
 
-use super::{
-    Proof,
-    VerifyingKey,
-    PreparedVerifyingKey
-};
+use super::{PreparedVerifyingKey, Proof, VerifyingKey};
 
-use ::{
-    SynthesisError
-};
+use SynthesisError;
 
-pub fn prepare_verifying_key<E: Engine>(
-    vk: &VerifyingKey<E>
-) -> PreparedVerifyingKey<E>
-{
+pub fn prepare_verifying_key<E: Engine>(vk: &VerifyingKey<E>) -> PreparedVerifyingKey<E> {
     let mut gamma = vk.gamma_g2;
     gamma.negate();
     let mut delta = vk.delta_g2;
@@ -28,16 +14,15 @@ pub fn prepare_verifying_key<E: Engine>(
         alpha_g1_beta_g2: E::pairing(vk.alpha_g1, vk.beta_g2),
         neg_gamma_g2: gamma.prepare(),
         neg_delta_g2: delta.prepare(),
-        ic: vk.ic.clone()
+        ic: vk.ic.clone(),
     }
 }
 
 pub fn verify_proof<'a, E: Engine>(
     pvk: &'a PreparedVerifyingKey<E>,
     proof: &Proof<E>,
-    public_inputs: &[E::Fr]
-) -> Result<bool, SynthesisError>
-{
+    public_inputs: &[E::Fr],
+) -> Result<bool, SynthesisError> {
     if (public_inputs.len() + 1) != pvk.ic.len() {
         return Err(SynthesisError::MalformedVerifyingKey);
     }
@@ -56,11 +41,11 @@ pub fn verify_proof<'a, E: Engine>(
     // A * B + inputs * (-gamma) + C * (-delta) = alpha * beta
     // which allows us to do a single final exponentiation.
 
-    Ok(E::final_exponentiation(
-        &E::miller_loop([
+    Ok(E::final_exponentiation(&E::miller_loop(
+        [
             (&proof.a.prepare(), &proof.b.prepare()),
             (&acc.into_affine().prepare(), &pvk.neg_gamma_g2),
-            (&proof.c.prepare(), &pvk.neg_delta_g2)
-        ].into_iter())
-    ).unwrap() == pvk.alpha_g1_beta_g2)
+            (&proof.c.prepare(), &pvk.neg_delta_g2),
+        ].into_iter(),
+    )).unwrap() == pvk.alpha_g1_beta_g2)
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -15,7 +15,6 @@ mod multiexp;
 use pairing::{Engine, Field};
 use std::error::Error;
 use std::fmt;
-use std::io;
 use std::marker::PhantomData;
 use std::ops::{Add, Sub};
 
@@ -173,18 +172,12 @@ pub enum SynthesisError {
     PolynomialDegreeTooLarge,
     /// During proof generation, we encountered an identity in the CRS
     UnexpectedIdentity,
-    /// During proof generation, we encountered an I/O error with the CRS
-    IoError(io::Error),
+    /// During proof generation, we expected more bases from source
+    TooFewBases,
     /// During verification, our verifying key was malformed.
     MalformedVerifyingKey,
     /// During CRS generation, we observed an unconstrained auxillary variable
     UnconstrainedVariable,
-}
-
-impl From<io::Error> for SynthesisError {
-    fn from(e: io::Error) -> SynthesisError {
-        SynthesisError::IoError(e)
-    }
 }
 
 impl Error for SynthesisError {
@@ -197,7 +190,7 @@ impl Error for SynthesisError {
             SynthesisError::Unsatisfiable => "unsatisfiable constraint system",
             SynthesisError::PolynomialDegreeTooLarge => "polynomial degree is too large",
             SynthesisError::UnexpectedIdentity => "encountered an identity element in the CRS",
-            SynthesisError::IoError(_) => "encountered an I/O error",
+            SynthesisError::TooFewBases => "expected more bases from source",
             SynthesisError::MalformedVerifyingKey => "malformed verifying key",
             SynthesisError::UnconstrainedVariable => "auxillary variable was unconstrained",
         }
@@ -206,12 +199,7 @@ impl Error for SynthesisError {
 
 impl fmt::Display for SynthesisError {
     fn fmt(&self, f: &mut fmt::Formatter) -> Result<(), fmt::Error> {
-        if let SynthesisError::IoError(ref e) = self {
-            write!(f, "I/O error: ")?;
-            e.fmt(f)
-        } else {
-            write!(f, "{}", self.description())
-        }
+        write!(f, "{}", self.description())
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -13,7 +13,6 @@ pub mod multicore;
 mod multiexp;
 
 use pairing::{Engine, Field};
-
 use std::error::Error;
 use std::fmt;
 use std::io;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -85,9 +85,9 @@ impl<E: Engine> Add<(E::Fr, Variable)> for LinearCombination<E> {
 impl<E: Engine> Sub<(E::Fr, Variable)> for LinearCombination<E> {
     type Output = LinearCombination<E>;
 
+    #[cfg_attr(feature = "cargo-clippy", allow(suspicious_arithmetic_impl))]
     fn sub(self, (mut coeff, var): (E::Fr, Variable)) -> LinearCombination<E> {
         coeff.negate();
-
         self + (coeff, var)
     }
 }
@@ -207,7 +207,7 @@ impl Error for SynthesisError {
 
 impl fmt::Display for SynthesisError {
     fn fmt(&self, f: &mut fmt::Formatter) -> Result<(), fmt::Error> {
-        if let &SynthesisError::IoError(ref e) = self {
+        if let SynthesisError::IoError(ref e) = self {
             write!(f, "I/O error: ")?;
             e.fmt(f)
         } else {
@@ -272,7 +272,7 @@ pub trait ConstraintSystem<E: Engine>: Sized {
     fn get_root(&mut self) -> &mut Self::Root;
 
     /// Begin a namespace for this constraint system.
-    fn namespace<'a, NR, N>(&'a mut self, name_fn: N) -> Namespace<'a, E, Self::Root>
+    fn namespace<NR, N>(&mut self, name_fn: N) -> Namespace<E, Self::Root>
     where
         NR: Into<String>,
         N: FnOnce() -> NR,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,24 +1,24 @@
-extern crate pairing;
-extern crate rand;
-extern crate num_cpus;
+extern crate bit_vec;
+extern crate byteorder;
+extern crate crossbeam;
 extern crate futures;
 extern crate futures_cpupool;
-extern crate bit_vec;
-extern crate crossbeam;
-extern crate byteorder;
+extern crate num_cpus;
+extern crate pairing;
+extern crate rand;
 
-pub mod multicore;
-mod multiexp;
 pub mod domain;
 pub mod groth16;
+pub mod multicore;
+mod multiexp;
 
 use pairing::{Engine, Field};
 
-use std::ops::{Add, Sub};
-use std::fmt;
 use std::error::Error;
+use std::fmt;
 use std::io;
 use std::marker::PhantomData;
+use std::ops::{Add, Sub};
 
 /// Computations are expressed in terms of arithmetic circuits, in particular
 /// rank-1 quadratic constraint systems. The `Circuit` trait represents a
@@ -26,10 +26,7 @@ use std::marker::PhantomData;
 /// CRS generation and during proving.
 pub trait Circuit<E: Engine> {
     /// Synthesize the circuit into a rank-1 quadratic constraint system
-    fn synthesize<CS: ConstraintSystem<E>>(
-        self,
-        cs: &mut CS
-    ) -> Result<(), SynthesisError>;
+    fn synthesize<CS: ConstraintSystem<E>>(self, cs: &mut CS) -> Result<(), SynthesisError>;
 }
 
 /// Represents a variable in our constraint system.
@@ -55,7 +52,7 @@ impl Variable {
 #[derive(Copy, Clone, PartialEq, Debug)]
 pub enum Index {
     Input(usize),
-    Aux(usize)
+    Aux(usize),
 }
 
 /// This represents a linear combination of some variables, with coefficients
@@ -182,7 +179,7 @@ pub enum SynthesisError {
     /// During verification, our verifying key was malformed.
     MalformedVerifyingKey,
     /// During CRS generation, we observed an unconstrained auxillary variable
-    UnconstrainedVariable
+    UnconstrainedVariable,
 }
 
 impl From<io::Error> for SynthesisError {
@@ -194,14 +191,16 @@ impl From<io::Error> for SynthesisError {
 impl Error for SynthesisError {
     fn description(&self) -> &str {
         match *self {
-            SynthesisError::AssignmentMissing => "an assignment for a variable could not be computed",
+            SynthesisError::AssignmentMissing => {
+                "an assignment for a variable could not be computed"
+            }
             SynthesisError::DivisionByZero => "division by zero",
             SynthesisError::Unsatisfiable => "unsatisfiable constraint system",
             SynthesisError::PolynomialDegreeTooLarge => "polynomial degree is too large",
             SynthesisError::UnexpectedIdentity => "encountered an identity element in the CRS",
             SynthesisError::IoError(_) => "encountered an I/O error",
             SynthesisError::MalformedVerifyingKey => "malformed verifying key",
-            SynthesisError::UnconstrainedVariable => "auxillary variable was unconstrained"
+            SynthesisError::UnconstrainedVariable => "auxillary variable was unconstrained",
         }
     }
 }
@@ -218,7 +217,7 @@ impl fmt::Display for SynthesisError {
 }
 
 /// Represents a constraint system which can have new variables
-/// allocated and constrains between them formed.
+/// allocated and constraints between them formed.
 pub trait ConstraintSystem<E: Engine>: Sized {
     /// Represents the type of the "root" of this constraint system
     /// so that nested namespaces can minimize indirection.
@@ -233,40 +232,36 @@ pub trait ConstraintSystem<E: Engine>: Sized {
     /// determine the assignment of the variable. The given `annotation` function is invoked
     /// in testing contexts in order to derive a unique name for this variable in the current
     /// namespace.
-    fn alloc<F, A, AR>(
-        &mut self,
-        annotation: A,
-        f: F
-    ) -> Result<Variable, SynthesisError>
-        where F: FnOnce() -> Result<E::Fr, SynthesisError>, A: FnOnce() -> AR, AR: Into<String>;
+    fn alloc<F, A, AR>(&mut self, annotation: A, f: F) -> Result<Variable, SynthesisError>
+    where
+        F: FnOnce() -> Result<E::Fr, SynthesisError>,
+        A: FnOnce() -> AR,
+        AR: Into<String>;
 
     /// Allocate a public variable in the constraint system. The provided function is used to
     /// determine the assignment of the variable.
-    fn alloc_input<F, A, AR>(
-        &mut self,
-        annotation: A,
-        f: F
-    ) -> Result<Variable, SynthesisError>
-        where F: FnOnce() -> Result<E::Fr, SynthesisError>, A: FnOnce() -> AR, AR: Into<String>;
+    fn alloc_input<F, A, AR>(&mut self, annotation: A, f: F) -> Result<Variable, SynthesisError>
+    where
+        F: FnOnce() -> Result<E::Fr, SynthesisError>,
+        A: FnOnce() -> AR,
+        AR: Into<String>;
 
     /// Enforce that `A` * `B` = `C`. The `annotation` function is invoked in testing contexts
     /// in order to derive a unique name for the constraint in the current namespace.
-    fn enforce<A, AR, LA, LB, LC>(
-        &mut self,
-        annotation: A,
-        a: LA,
-        b: LB,
-        c: LC
-    )
-        where A: FnOnce() -> AR, AR: Into<String>,
-              LA: FnOnce(LinearCombination<E>) -> LinearCombination<E>,
-              LB: FnOnce(LinearCombination<E>) -> LinearCombination<E>,
-              LC: FnOnce(LinearCombination<E>) -> LinearCombination<E>;
+    fn enforce<A, AR, LA, LB, LC>(&mut self, annotation: A, a: LA, b: LB, c: LC)
+    where
+        A: FnOnce() -> AR,
+        AR: Into<String>,
+        LA: FnOnce(LinearCombination<E>) -> LinearCombination<E>,
+        LB: FnOnce(LinearCombination<E>) -> LinearCombination<E>,
+        LC: FnOnce(LinearCombination<E>) -> LinearCombination<E>;
 
     /// Create a new (sub)namespace and enter into it. Not intended
     /// for downstream use; use `namespace` instead.
     fn push_namespace<NR, N>(&mut self, name_fn: N)
-        where NR: Into<String>, N: FnOnce() -> NR;
+    where
+        NR: Into<String>,
+        N: FnOnce() -> NR;
 
     /// Exit out of the existing namespace. Not intended for
     /// downstream use; use `namespace` instead.
@@ -277,11 +272,10 @@ pub trait ConstraintSystem<E: Engine>: Sized {
     fn get_root(&mut self) -> &mut Self::Root;
 
     /// Begin a namespace for this constraint system.
-    fn namespace<'a, NR, N>(
-        &'a mut self,
-        name_fn: N
-    ) -> Namespace<'a, E, Self::Root>
-        where NR: Into<String>, N: FnOnce() -> NR
+    fn namespace<'a, NR, N>(&'a mut self, name_fn: N) -> Namespace<'a, E, Self::Root>
+    where
+        NR: Into<String>,
+        N: FnOnce() -> NR,
     {
         self.get_root().push_namespace(name_fn);
 
@@ -300,37 +294,31 @@ impl<'cs, E: Engine, CS: ConstraintSystem<E>> ConstraintSystem<E> for Namespace<
         CS::one()
     }
 
-    fn alloc<F, A, AR>(
-        &mut self,
-        annotation: A,
-        f: F
-    ) -> Result<Variable, SynthesisError>
-        where F: FnOnce() -> Result<E::Fr, SynthesisError>, A: FnOnce() -> AR, AR: Into<String>
+    fn alloc<F, A, AR>(&mut self, annotation: A, f: F) -> Result<Variable, SynthesisError>
+    where
+        F: FnOnce() -> Result<E::Fr, SynthesisError>,
+        A: FnOnce() -> AR,
+        AR: Into<String>,
     {
         self.0.alloc(annotation, f)
     }
 
-    fn alloc_input<F, A, AR>(
-        &mut self,
-        annotation: A,
-        f: F
-    ) -> Result<Variable, SynthesisError>
-        where F: FnOnce() -> Result<E::Fr, SynthesisError>, A: FnOnce() -> AR, AR: Into<String>
+    fn alloc_input<F, A, AR>(&mut self, annotation: A, f: F) -> Result<Variable, SynthesisError>
+    where
+        F: FnOnce() -> Result<E::Fr, SynthesisError>,
+        A: FnOnce() -> AR,
+        AR: Into<String>,
     {
         self.0.alloc_input(annotation, f)
     }
 
-    fn enforce<A, AR, LA, LB, LC>(
-        &mut self,
-        annotation: A,
-        a: LA,
-        b: LB,
-        c: LC
-    )
-        where A: FnOnce() -> AR, AR: Into<String>,
-              LA: FnOnce(LinearCombination<E>) -> LinearCombination<E>,
-              LB: FnOnce(LinearCombination<E>) -> LinearCombination<E>,
-              LC: FnOnce(LinearCombination<E>) -> LinearCombination<E>
+    fn enforce<A, AR, LA, LB, LC>(&mut self, annotation: A, a: LA, b: LB, c: LC)
+    where
+        A: FnOnce() -> AR,
+        AR: Into<String>,
+        LA: FnOnce(LinearCombination<E>) -> LinearCombination<E>,
+        LB: FnOnce(LinearCombination<E>) -> LinearCombination<E>,
+        LC: FnOnce(LinearCombination<E>) -> LinearCombination<E>,
     {
         self.0.enforce(annotation, a, b, c)
     }
@@ -340,18 +328,18 @@ impl<'cs, E: Engine, CS: ConstraintSystem<E>> ConstraintSystem<E> for Namespace<
     // never a root constraint system.
 
     fn push_namespace<NR, N>(&mut self, _: N)
-        where NR: Into<String>, N: FnOnce() -> NR
+    where
+        NR: Into<String>,
+        N: FnOnce() -> NR,
     {
         panic!("only the root's push_namespace should be called");
     }
 
-    fn pop_namespace(&mut self)
-    {
+    fn pop_namespace(&mut self) {
         panic!("only the root's pop_namespace should be called");
     }
 
-    fn get_root(&mut self) -> &mut Self::Root
-    {
+    fn get_root(&mut self) -> &mut Self::Root {
         self.0.get_root()
     }
 }
@@ -371,54 +359,48 @@ impl<'cs, E: Engine, CS: ConstraintSystem<E>> ConstraintSystem<E> for &'cs mut C
         CS::one()
     }
 
-    fn alloc<F, A, AR>(
-        &mut self,
-        annotation: A,
-        f: F
-    ) -> Result<Variable, SynthesisError>
-        where F: FnOnce() -> Result<E::Fr, SynthesisError>, A: FnOnce() -> AR, AR: Into<String>
+    fn alloc<F, A, AR>(&mut self, annotation: A, f: F) -> Result<Variable, SynthesisError>
+    where
+        F: FnOnce() -> Result<E::Fr, SynthesisError>,
+        A: FnOnce() -> AR,
+        AR: Into<String>,
     {
         (**self).alloc(annotation, f)
     }
 
-    fn alloc_input<F, A, AR>(
-        &mut self,
-        annotation: A,
-        f: F
-    ) -> Result<Variable, SynthesisError>
-        where F: FnOnce() -> Result<E::Fr, SynthesisError>, A: FnOnce() -> AR, AR: Into<String>
+    fn alloc_input<F, A, AR>(&mut self, annotation: A, f: F) -> Result<Variable, SynthesisError>
+    where
+        F: FnOnce() -> Result<E::Fr, SynthesisError>,
+        A: FnOnce() -> AR,
+        AR: Into<String>,
     {
         (**self).alloc_input(annotation, f)
     }
 
-    fn enforce<A, AR, LA, LB, LC>(
-        &mut self,
-        annotation: A,
-        a: LA,
-        b: LB,
-        c: LC
-    )
-        where A: FnOnce() -> AR, AR: Into<String>,
-              LA: FnOnce(LinearCombination<E>) -> LinearCombination<E>,
-              LB: FnOnce(LinearCombination<E>) -> LinearCombination<E>,
-              LC: FnOnce(LinearCombination<E>) -> LinearCombination<E>
+    fn enforce<A, AR, LA, LB, LC>(&mut self, annotation: A, a: LA, b: LB, c: LC)
+    where
+        A: FnOnce() -> AR,
+        AR: Into<String>,
+        LA: FnOnce(LinearCombination<E>) -> LinearCombination<E>,
+        LB: FnOnce(LinearCombination<E>) -> LinearCombination<E>,
+        LC: FnOnce(LinearCombination<E>) -> LinearCombination<E>,
     {
         (**self).enforce(annotation, a, b, c)
     }
 
     fn push_namespace<NR, N>(&mut self, name_fn: N)
-        where NR: Into<String>, N: FnOnce() -> NR
+    where
+        NR: Into<String>,
+        N: FnOnce() -> NR,
     {
         (**self).push_namespace(name_fn)
     }
 
-    fn pop_namespace(&mut self)
-    {
+    fn pop_namespace(&mut self) {
         (**self).pop_namespace()
     }
 
-    fn get_root(&mut self) -> &mut Self::Root
-    {
+    fn get_root(&mut self) -> &mut Self::Root {
         (**self).get_root()
     }
 }

--- a/src/multicore.rs
+++ b/src/multicore.rs
@@ -21,7 +21,7 @@ impl Worker {
     // CPUs configured.
     pub(crate) fn new_with_cpus(cpus: usize) -> Worker {
         Worker {
-            cpus: cpus,
+            cpus,
             pool: CpuPool::new(cpus),
         }
     }
@@ -58,6 +58,12 @@ impl Worker {
         };
 
         crossbeam::scope(|scope| f(scope, chunk_size))
+    }
+}
+
+impl Default for Worker {
+    fn default() -> Self {
+        Self::new_with_cpus(num_cpus::get())
     }
 }
 

--- a/src/multicore.rs
+++ b/src/multicore.rs
@@ -4,15 +4,15 @@
 //! crossbeam but may be extended in the future to
 //! allow for various parallelism strategies.
 
-use num_cpus;
-use futures::{Future, IntoFuture, Poll};
-use futures_cpupool::{CpuPool, CpuFuture};
 use crossbeam::{self, Scope};
+use futures::{Future, IntoFuture, Poll};
+use futures_cpupool::{CpuFuture, CpuPool};
+use num_cpus;
 
 #[derive(Clone)]
 pub struct Worker {
     cpus: usize,
-    pool: CpuPool
+    pool: CpuPool,
 }
 
 impl Worker {
@@ -22,7 +22,7 @@ impl Worker {
     pub(crate) fn new_with_cpus(cpus: usize) -> Worker {
         Worker {
             cpus: cpus,
-            pool: CpuPool::new(cpus)
+            pool: CpuPool::new(cpus),
         }
     }
 
@@ -34,26 +34,22 @@ impl Worker {
         log2_floor(self.cpus)
     }
 
-    pub fn compute<F, R>(
-        &self, f: F
-    ) -> WorkerFuture<R::Item, R::Error>
-        where F: FnOnce() -> R + Send + 'static,
-              R: IntoFuture + 'static,
-              R::Future: Send + 'static,
-              R::Item: Send + 'static,
-              R::Error: Send + 'static
+    pub fn compute<F, R>(&self, f: F) -> WorkerFuture<R::Item, R::Error>
+    where
+        F: FnOnce() -> R + Send + 'static,
+        R: IntoFuture + 'static,
+        R::Future: Send + 'static,
+        R::Item: Send + 'static,
+        R::Error: Send + 'static,
     {
         WorkerFuture {
-            future: self.pool.spawn_fn(f)
+            future: self.pool.spawn_fn(f),
         }
     }
 
-    pub fn scope<'a, F, R>(
-        &self,
-        elements: usize,
-        f: F
-    ) -> R
-        where F: FnOnce(&Scope<'a>, usize) -> R
+    pub fn scope<'a, F, R>(&self, elements: usize, f: F) -> R
+    where
+        F: FnOnce(&Scope<'a>, usize) -> R,
     {
         let chunk_size = if elements < self.cpus {
             1
@@ -61,22 +57,19 @@ impl Worker {
             elements / self.cpus
         };
 
-        crossbeam::scope(|scope| {
-            f(scope, chunk_size)
-        })
+        crossbeam::scope(|scope| f(scope, chunk_size))
     }
 }
 
 pub struct WorkerFuture<T, E> {
-    future: CpuFuture<T, E>
+    future: CpuFuture<T, E>,
 }
 
 impl<T: Send + 'static, E: Send + 'static> Future for WorkerFuture<T, E> {
     type Item = T;
     type Error = E;
 
-    fn poll(&mut self) -> Poll<Self::Item, Self::Error>
-    {
+    fn poll(&mut self) -> Poll<Self::Item, Self::Error> {
         self.future.poll()
     }
 }
@@ -86,7 +79,7 @@ fn log2_floor(num: usize) -> u32 {
 
     let mut pow = 0;
 
-    while (1 << (pow+1)) <= num {
+    while (1 << (pow + 1)) <= num {
         pow += 1;
     }
 

--- a/src/multiexp.rs
+++ b/src/multiexp.rs
@@ -2,7 +2,6 @@ use bit_vec::{self, BitVec};
 use futures::Future;
 use multicore::Worker;
 use pairing::{CurveAffine, CurveProjective, Engine, Field, PrimeField, PrimeFieldRepr};
-use std::io;
 use std::iter;
 use std::sync::Arc;
 use SynthesisError;
@@ -40,10 +39,7 @@ impl<G: CurveAffine> Source<G> for (Arc<Vec<G>>, usize) {
         to: &mut <G as CurveAffine>::Projective,
     ) -> Result<(), SynthesisError> {
         if self.0.len() <= self.1 {
-            return Err(io::Error::new(
-                io::ErrorKind::UnexpectedEof,
-                "expected more bases from source",
-            ).into());
+            return Err(SynthesisError::TooFewBases);
         }
 
         if self.0[self.1].is_zero() {
@@ -59,10 +55,7 @@ impl<G: CurveAffine> Source<G> for (Arc<Vec<G>>, usize) {
 
     fn skip(&mut self, amt: usize) -> Result<(), SynthesisError> {
         if self.0.len() <= self.1 {
-            return Err(io::Error::new(
-                io::ErrorKind::UnexpectedEof,
-                "expected more bases from source",
-            ).into());
+            return Err(SynthesisError::TooFewBases);
         }
 
         self.1 += amt;

--- a/src/multiexp.rs
+++ b/src/multiexp.rs
@@ -1,12 +1,11 @@
 use super::multicore::Worker;
+use super::SynthesisError;
 use bit_vec::{self, BitVec};
 use futures::Future;
 use pairing::{CurveAffine, CurveProjective, Engine, Field, PrimeField, PrimeFieldRepr};
 use std::io;
 use std::iter;
 use std::sync::Arc;
-
-use super::SynthesisError;
 
 /// An object that builds a source of bases.
 pub trait SourceBuilder<G: CurveAffine>: Send + Sync + 'static + Clone {

--- a/src/multiexp.rs
+++ b/src/multiexp.rs
@@ -1,11 +1,11 @@
-use super::multicore::Worker;
-use super::SynthesisError;
 use bit_vec::{self, BitVec};
 use futures::Future;
+use multicore::Worker;
 use pairing::{CurveAffine, CurveProjective, Engine, Field, PrimeField, PrimeFieldRepr};
 use std::io;
 use std::iter;
 use std::sync::Arc;
+use SynthesisError;
 
 /// An object that builds a source of bases.
 pub trait SourceBuilder<G: CurveAffine>: Send + Sync + 'static + Clone {

--- a/src/multiexp.rs
+++ b/src/multiexp.rs
@@ -1,17 +1,10 @@
-use pairing::{
-    CurveAffine,
-    CurveProjective,
-    Engine,
-    PrimeField,
-    Field,
-    PrimeFieldRepr
-};
-use std::sync::Arc;
-use std::io;
-use bit_vec::{self, BitVec};
-use std::iter;
-use futures::{Future};
 use super::multicore::Worker;
+use bit_vec::{self, BitVec};
+use futures::Future;
+use pairing::{CurveAffine, CurveProjective, Engine, Field, PrimeField, PrimeFieldRepr};
+use std::io;
+use std::iter;
+use std::sync::Arc;
 
 use super::SynthesisError;
 
@@ -25,7 +18,10 @@ pub trait SourceBuilder<G: CurveAffine>: Send + Sync + 'static + Clone {
 /// A source of bases, like an iterator.
 pub trait Source<G: CurveAffine> {
     /// Parses the element from the source. Fails if the point is at infinity.
-    fn add_assign_mixed(&mut self, to: &mut <G as CurveAffine>::Projective) -> Result<(), SynthesisError>;
+    fn add_assign_mixed(
+        &mut self,
+        to: &mut <G as CurveAffine>::Projective,
+    ) -> Result<(), SynthesisError>;
 
     /// Skips `amt` elements from the source, avoiding deserialization.
     fn skip(&mut self, amt: usize) -> Result<(), SynthesisError>;
@@ -40,13 +36,19 @@ impl<G: CurveAffine> SourceBuilder<G> for (Arc<Vec<G>>, usize) {
 }
 
 impl<G: CurveAffine> Source<G> for (Arc<Vec<G>>, usize) {
-    fn add_assign_mixed(&mut self, to: &mut <G as CurveAffine>::Projective) -> Result<(), SynthesisError> {
+    fn add_assign_mixed(
+        &mut self,
+        to: &mut <G as CurveAffine>::Projective,
+    ) -> Result<(), SynthesisError> {
         if self.0.len() <= self.1 {
-            return Err(io::Error::new(io::ErrorKind::UnexpectedEof, "expected more bases from source").into());
+            return Err(io::Error::new(
+                io::ErrorKind::UnexpectedEof,
+                "expected more bases from source",
+            ).into());
         }
 
         if self.0[self.1].is_zero() {
-            return Err(SynthesisError::UnexpectedIdentity)
+            return Err(SynthesisError::UnexpectedIdentity);
         }
 
         to.add_assign_mixed(&self.0[self.1]);
@@ -58,7 +60,10 @@ impl<G: CurveAffine> Source<G> for (Arc<Vec<G>>, usize) {
 
     fn skip(&mut self, amt: usize) -> Result<(), SynthesisError> {
         if self.0.len() <= self.1 {
-            return Err(io::Error::new(io::ErrorKind::UnexpectedEof, "expected more bases from source").into());
+            return Err(io::Error::new(
+                io::ErrorKind::UnexpectedEof,
+                "expected more bases from source",
+            ).into());
         }
 
         self.1 += amt;
@@ -69,7 +74,7 @@ impl<G: CurveAffine> Source<G> for (Arc<Vec<G>>, usize) {
 
 pub trait QueryDensity {
     /// Returns whether the base exists.
-    type Iter: Iterator<Item=bool>;
+    type Iter: Iterator<Item = bool>;
 
     fn iter(self) -> Self::Iter;
     fn get_query_size(self) -> Option<usize>;
@@ -98,7 +103,7 @@ impl<'a> QueryDensity for &'a FullDensity {
 
 pub struct DensityTracker {
     bv: BitVec,
-    total_density: usize
+    total_density: usize,
 }
 
 impl<'a> QueryDensity for &'a DensityTracker {
@@ -117,7 +122,7 @@ impl DensityTracker {
     pub fn new() -> DensityTracker {
         DensityTracker {
             bv: BitVec::new(),
-            total_density: 0
+            total_density: 0,
         }
     }
 
@@ -144,12 +149,13 @@ fn multiexp_inner<Q, D, G, S>(
     exponents: Arc<Vec<<<G::Engine as Engine>::Fr as PrimeField>::Repr>>,
     mut skip: u32,
     c: u32,
-    handle_trivial: bool
-) -> Box<Future<Item=<G as CurveAffine>::Projective, Error=SynthesisError>>
-    where for<'a> &'a Q: QueryDensity,
-          D: Send + Sync + 'static + Clone + AsRef<Q>,
-          G: CurveAffine,
-          S: SourceBuilder<G>
+    handle_trivial: bool,
+) -> Box<Future<Item = <G as CurveAffine>::Projective, Error = SynthesisError>>
+where
+    for<'a> &'a Q: QueryDensity,
+    D: Send + Sync + 'static + Clone + AsRef<Q>,
+    G: CurveAffine,
+    S: SourceBuilder<G>,
 {
     // Perform this region of the multiexp
     let this = {
@@ -218,16 +224,23 @@ fn multiexp_inner<Q, D, G, S>(
         // There's another region more significant. Calculate and join it with
         // this region recursively.
         Box::new(
-            this.join(multiexp_inner(pool, bases, density_map, exponents, skip, c, false))
-                .map(move |(this, mut higher)| {
-                    for _ in 0..c {
-                        higher.double();
-                    }
+            this.join(multiexp_inner(
+                pool,
+                bases,
+                density_map,
+                exponents,
+                skip,
+                c,
+                false,
+            )).map(move |(this, mut higher)| {
+                for _ in 0..c {
+                    higher.double();
+                }
 
-                    higher.add_assign(&this);
+                higher.add_assign(&this);
 
-                    higher
-                })
+                higher
+            }),
         )
     }
 }
@@ -238,12 +251,13 @@ pub fn multiexp<Q, D, G, S>(
     pool: &Worker,
     bases: S,
     density_map: D,
-    exponents: Arc<Vec<<<G::Engine as Engine>::Fr as PrimeField>::Repr>>
-) -> Box<Future<Item=<G as CurveAffine>::Projective, Error=SynthesisError>>
-    where for<'a> &'a Q: QueryDensity,
-          D: Send + Sync + 'static + Clone + AsRef<Q>,
-          G: CurveAffine,
-          S: SourceBuilder<G>
+    exponents: Arc<Vec<<<G::Engine as Engine>::Fr as PrimeField>::Repr>>,
+) -> Box<Future<Item = <G as CurveAffine>::Projective, Error = SynthesisError>>
+where
+    for<'a> &'a Q: QueryDensity,
+    D: Send + Sync + 'static + Clone + AsRef<Q>,
+    G: CurveAffine,
+    S: SourceBuilder<G>,
 {
     let c = if exponents.len() < 32 {
         3u32
@@ -265,9 +279,8 @@ pub fn multiexp<Q, D, G, S>(
 fn test_with_bls12() {
     fn naive_multiexp<G: CurveAffine>(
         bases: Arc<Vec<G>>,
-        exponents: Arc<Vec<<G::Scalar as PrimeField>::Repr>>
-    ) -> G::Projective
-    {
+        exponents: Arc<Vec<<G::Scalar as PrimeField>::Repr>>,
+    ) -> G::Projective {
         assert_eq!(bases.len(), exponents.len());
 
         let mut acc = G::Projective::zero();
@@ -279,25 +292,28 @@ fn test_with_bls12() {
         acc
     }
 
-    use rand::{self, Rand};
     use pairing::bls12_381::Bls12;
+    use rand::{self, Rand};
 
     const SAMPLES: usize = 1 << 14;
 
     let rng = &mut rand::thread_rng();
-    let v = Arc::new((0..SAMPLES).map(|_| <Bls12 as Engine>::Fr::rand(rng).into_repr()).collect::<Vec<_>>());
-    let g = Arc::new((0..SAMPLES).map(|_| <Bls12 as Engine>::G1::rand(rng).into_affine()).collect::<Vec<_>>());
+    let v = Arc::new(
+        (0..SAMPLES)
+            .map(|_| <Bls12 as Engine>::Fr::rand(rng).into_repr())
+            .collect::<Vec<_>>(),
+    );
+    let g = Arc::new(
+        (0..SAMPLES)
+            .map(|_| <Bls12 as Engine>::G1::rand(rng).into_affine())
+            .collect::<Vec<_>>(),
+    );
 
     let naive = naive_multiexp(g.clone(), v.clone());
 
     let pool = Worker::new();
 
-    let fast = multiexp(
-        &pool,
-        (g, 0),
-        FullDensity,
-        v
-    ).wait().unwrap();
+    let fast = multiexp(&pool, (g, 0), FullDensity, v).wait().unwrap();
 
     assert_eq!(naive, fast);
 }


### PR DESCRIPTION
* Run `cargo fmt`
* Remove some whitespace to make `cargo fmt` alphabetize imports
* Remove redundant `super` qualifiers from imports
* Apply or explicitly ignore all of clippy's suggestions, which included adding some `Default`, `AsRef` and `AsMut` instances.
* Add a new error field instead of using IoError

No expected changes to functionality or performance