### PR TITLE
Adding Single-threaded mode

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,11 +12,12 @@ version = "0.1.0"
 rand = "0.4"
 bit-vec = "0.4.4"
 futures = "0.1"
-futures-cpupool = "0.1"
-num_cpus = "1"
-crossbeam = "0.3"
 pairing = "0.14"
 byteorder = "1"
+futures-cpupool = { version =  "0.1", optional = true }
+num_cpus = { version =  "1", optional = true }
+crossbeam = { version =  "0.3", optional = true }
 
 [features]
-default = []
+default = ["multithread"]
+multithread = ["futures-cpupool", "num_cpus", "crossbeam"] 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,11 +1,16 @@
 extern crate pairing;
 extern crate rand;
-extern crate num_cpus;
 extern crate futures;
-extern crate futures_cpupool;
 extern crate bit_vec;
-extern crate crossbeam;
 extern crate byteorder;
+
+#[cfg(multithread)]
+extern crate futures_cpupool;
+#[cfg(multithread)]
+extern crate num_cpus;
+#[cfg(multithread)]
+extern crate crossbeam;
+
 
 pub mod multicore;
 mod multiexp;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -4,13 +4,12 @@ extern crate futures;
 extern crate bit_vec;
 extern crate byteorder;
 
-#[cfg(multithread)]
+#[cfg(feature = "multithread")]
 extern crate futures_cpupool;
-#[cfg(multithread)]
+#[cfg(feature = "multithread")]
 extern crate num_cpus;
-#[cfg(multithread)]
+#[cfg(feature = "multithread")]
 extern crate crossbeam;
-
 
 pub mod multicore;
 mod multiexp;

--- a/src/multicore.rs
+++ b/src/multicore.rs
@@ -1,8 +1,11 @@
 //! This is an interface for dealing with the kinds of
 //! parallel computations involved in bellman. It's
-//! currently just a thin wrapper around CpuPool and
+//! currently just an optional thin wrapper around CpuPool and
 //! crossbeam but may be extended in the future to
 //! allow for various parallelism strategies.
+//! Compile without the "multithread" feature for targets that
+//! don't support parallel computation.
+
 use futures::{Future, IntoFuture, Poll};
 
 #[cfg(feature = "multithread")]
@@ -81,6 +84,7 @@ pub struct WorkerFuture<T, E> {
     future: CpuFuture<T, E>
 }
 
+//Dummy worker for single-threaded mode
 #[cfg(not(feature = "multithread"))]
 #[derive(Clone)]
 pub struct Worker {}
@@ -122,6 +126,7 @@ impl Worker {
     }
 }
 
+//
 #[cfg(not(feature = "multithread"))]
 pub struct Scope {
 }


### PR DESCRIPTION
Hello everybody,
a couple of people in the community seem to be interested to run bellman in single-threaded mode, in particular to target wasm.
This PR adds a "multithread" compile option which is activated as default. 
In order to run in single-threaded mode compile using `--no-std-features`.
