### PR TITLE
Remove documentation entry from Cargo.toml

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,6 @@
 authors = ["Sean Bowe <ewillbefull@gmail.com>"]
 description = "zk-SNARK library"
 readme = "README.md"
-documentation = "https://github.com/ebfull/bellman"
 homepage = "https://github.com/ebfull/bellman"
 license = "MIT/Apache-2.0"
 name = "bellman"


### PR DESCRIPTION
Clicking `Documentation` button on [crates.io](https://crates.io/crates/bellman) redirects user to github. If you remove `documentation` entry from Cargo.toml it will redirect to [docs.rs](https://docs.rs/bellman) instead