### PR TITLE
Makes multiexp module public

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -142,7 +142,7 @@ pub mod gadgets;
 #[cfg(feature = "groth16")]
 pub mod groth16;
 pub mod multicore;
-mod multiexp;
+pub mod multiexp;
 
 use ff::PrimeField;
 


### PR DESCRIPTION
...to access SourceBuilder. It is useful to set ParameterSource bounds like:
> ...
where
        P: groth16::ParameterSource< Bls12>,
        P::G1Builder: SourceBuilder<< Bls12 as Engine>::G1Affine>,
        P::G2Builder: SourceBuilder<< Bls12 as Engine>::G2Affine>,