### PR TITLE
Fix deref breakage with nightly-2020-10-06

### DIFF
--- a/src/groth16/generator.rs
+++ b/src/groth16/generator.rs
@@ -398,8 +398,8 @@ where
                             *b_g2 = g2_wnaf.scalar(&bt);
                         }
 
-                        at.mul_assign(&beta);
-                        bt.mul_assign(&alpha);
+                        at *= beta;
+                        bt *= alpha;
 
                         let mut e = at;
                         e.add_assign(&bt);


### PR DESCRIPTION
Fixes the following error:
```
cannot multiply-assign `<E as Engine>::Fr` by `&&<E as Engine>::Fr`
```

I think this is related to https://github.com/rust-lang/rust/issues/77638