### PR TITLE
Update to bitvec 0.21

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ version = "0.9.0"
 edition = "2018"
 
 [dependencies]
-bitvec = "0.20"
+bitvec = "0.21"
 blake2s_simd = "0.5"
 ff = "0.9"
 futures = "0.1"


### PR DESCRIPTION
Note: You might want to merge this after https://github.com/zkcrypto/ff/pull/52 has been merged and published, to avoid having two different versions of bitvec in the dependency graph.