### PR TITLE
Fix zero-coefficient bug

### DIFF
--- a/src/groth16/prover.rs
+++ b/src/groth16/prover.rs
@@ -28,25 +28,27 @@ fn eval<S: PrimeField>(
     for &(index, coeff) in lc.0.iter() {
         let mut tmp;
 
-        match index {
-            Variable(Index::Input(i)) => {
-                tmp = input_assignment[i];
-                if let Some(ref mut v) = input_density {
-                    v.inc(i);
+        if !coeff.is_zero_vartime() {
+            match index {
+                Variable(Index::Input(i)) => {
+                    tmp = input_assignment[i];
+                    if let Some(ref mut v) = input_density {
+                        v.inc(i);
+                    }
+                }
+                Variable(Index::Aux(i)) => {
+                    tmp = aux_assignment[i];
+                    if let Some(ref mut v) = aux_density {
+                        v.inc(i);
+                    }
                 }
             }
-            Variable(Index::Aux(i)) => {
-                tmp = aux_assignment[i];
-                if let Some(ref mut v) = aux_density {
-                    v.inc(i);
-                }
-            }
-        }
 
-        if coeff != S::one() {
-            tmp *= coeff;
+            if coeff != S::one() {
+                tmp *= coeff;
+            }
+            acc += tmp;
         }
-        acc += tmp;
     }
 
     acc

--- a/src/groth16/tests/mod.rs
+++ b/src/groth16/tests/mod.rs
@@ -390,24 +390,24 @@ struct MultWithZeroCoeffs<F> {
 
 impl<F: ff::PrimeField> Circuit<F> for &MultWithZeroCoeffs<F> {
     fn synthesize<CS: ConstraintSystem<F>>(self, cs: &mut CS) -> Result<(), SynthesisError> {
-        let a = cs.alloc_input(|| "a", || Ok(self.a.unwrap()))?;
-        let b = cs.alloc_input(|| "b", || Ok(self.b.unwrap()))?;
-        let c = cs.alloc_input(|| "c", || Ok(self.c.unwrap()))?;
+        let a = cs.alloc(|| "a", || Ok(self.a.unwrap()))?;
+        let b = cs.alloc(|| "b", || Ok(self.b.unwrap()))?;
+        let c = cs.alloc(|| "c", || Ok(self.c.unwrap()))?;
         if self.one_var {
             cs.enforce(
                 || "cs",
-                // notice the zero coefficients
-                |z| z + (F::from(0), CS::one()) + a,
+                // notice the zero coefficient on the B term
+                |z| z + a,
                 |z| z + (F::from(0), CS::one()) + b,
-                |z| z + (F::from(0), CS::one()) + c,
+                |z| z + c,
             );
         } else {
             cs.enforce(
                 || "cs",
-                // notice the zero coefficients
-                |z| z + (F::from(0), a) + a,
+                // notice the zero coefficient on the B term
+                |z| z + a,
                 |z| z + (F::from(0), a) + b,
-                |z| z + (F::from(0), a) + c,
+                |z| z + c,
             );
         }
         Ok(())
@@ -415,26 +415,26 @@ impl<F: ff::PrimeField> Circuit<F> for &MultWithZeroCoeffs<F> {
 }
 
 fn zero_coeff_test(one_var: bool) {
-        let m = MultWithZeroCoeffs {
-            a: Some(Fr::from(5)),
-            b: Some(Fr::from(6)),
-            c: Some(Fr::from(30)),
-            one_var,
-        };
-        let g1 = Fr::one();
-        let g2 = Fr::one();
-        let alpha = Fr::from(48577);
-        let beta = Fr::from(22580);
-        let gamma = Fr::from(53332);
-        let delta = Fr::from(5481);
-        let tau = Fr::from(3673);
-        let pk =
-            generate_parameters::<DummyEngine, _>(&m, g1, g2, alpha, beta, gamma, delta, tau).unwrap();
-        let r = Fr::from(27134);
-        let s = Fr::from(17146);
-        let pf = create_proof(&m, &pk, r, s).unwrap();
-        let pvk = prepare_verifying_key(&pk.vk);
-        verify_proof(&pvk, &pf, &[Fr::from(5), Fr::from(6), Fr::from(30)]).unwrap();
+    let m = MultWithZeroCoeffs {
+        a: Some(Fr::from(5)),
+        b: Some(Fr::from(6)),
+        c: Some(Fr::from(30)),
+        one_var,
+    };
+    let g1 = Fr::one();
+    let g2 = Fr::one();
+    let alpha = Fr::from(48577);
+    let beta = Fr::from(22580);
+    let gamma = Fr::from(53332);
+    let delta = Fr::from(5481);
+    let tau = Fr::from(3673);
+    let pk =
+        generate_parameters::<DummyEngine, _>(&m, g1, g2, alpha, beta, gamma, delta, tau).unwrap();
+    let r = Fr::from(27134);
+    let s = Fr::from(17146);
+    let pf = create_proof(&m, &pk, r, s).unwrap();
+    let pvk = prepare_verifying_key(&pk.vk);
+    verify_proof(&pvk, &pf, &[]).unwrap();
 }
 
 #[test]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -208,7 +208,9 @@ impl<Scalar: PrimeField> Add<(Scalar, Variable)> for LinearCombination<Scalar> {
     type Output = LinearCombination<Scalar>;
 
     fn add(mut self, (coeff, var): (Scalar, Variable)) -> LinearCombination<Scalar> {
-        self.0.push((var, coeff));
+        if !coeff.is_zero_vartime() {
+            self.0.push((var, coeff));
+        }
 
         self
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -208,9 +208,7 @@ impl<Scalar: PrimeField> Add<(Scalar, Variable)> for LinearCombination<Scalar> {
     type Output = LinearCombination<Scalar>;
 
     fn add(mut self, (coeff, var): (Scalar, Variable)) -> LinearCombination<Scalar> {
-        if !coeff.is_zero_vartime() {
-            self.0.push((var, coeff));
-        }
+        self.0.push((var, coeff));
 
         self
     }


### PR DESCRIPTION
The groth16 prover and generator can sometimes get out-of-sync.

Without the included patch, the included test cases error with `"expected more
bases from source"`.

I did not dig closely, but I think the problem is a disagreement about how to
handle zero-coefficients in linear combinations.

Since such monomials are dead weight anyway, the included patch just filters
them out.

Feel free to dig deeper or implement a different patch!


P.S.: linear combinations depend only on the (public) circuit, which is why
variable-time zero testing does not leak secret data.
