### PR TITLE
Refactor `multiexp` to cache exponent chunks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,17 @@ and this project adheres to Rust's notion of
 [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- `bellman::multiexp::Exponent`
+
+### Changed
+- `bellman::multiexp::multiexp` now takes exponents as `Arc<Vec<Exponent<_>>>`
+  instead of `Arc<Vec<FieldBits<_>>>`.
+
+### Fixed
+- Migrating from `bitvec 0.22` to `bitvec 1.0` caused a performance regression
+  in `bellman::multiexp::multiexp`, slowing down proof creation. Some of that
+  performance has been regained by refactoring `multiexp`.
 
 ## [0.12.0] - 2022-05-04
 ### Changed

--- a/benches/slow.rs
+++ b/benches/slow.rs
@@ -4,7 +4,7 @@ use bellman::{
 };
 use bls12_381::{Bls12, Scalar};
 use criterion::{criterion_group, criterion_main, BenchmarkId, Criterion};
-use ff::{Field, PrimeFieldBits};
+use ff::Field;
 use group::{Curve, Group};
 use pairing::Engine;
 use rand_core::SeedableRng;
@@ -20,7 +20,7 @@ fn bench_parts(c: &mut Criterion) {
             .map(|_| Scalar::random(&mut rng))
             .collect::<Vec<_>>(),
     );
-    let v_bits = Arc::new(v.iter().map(|e| e.to_le_bits()).collect::<Vec<_>>());
+    let v_bits = Arc::new(v.iter().map(|e| e.into()).collect::<Vec<_>>());
     let g = Arc::new(
         (0..samples)
             .map(|_| <Bls12 as Engine>::G1::random(&mut rng).to_affine())

--- a/src/groth16/prover.rs
+++ b/src/groth16/prover.rs
@@ -230,7 +230,7 @@ where
         let a_len = a.len() - 1;
         a.truncate(a_len);
         // TODO: parallelize if it's even helpful
-        let a = Arc::new(a.into_iter().map(|s| s.0.to_le_bits()).collect::<Vec<_>>());
+        let a = Arc::new(a.into_iter().map(|s| s.0.into()).collect::<Vec<_>>());
 
         multiexp(&worker, params.get_h(a.len())?, FullDensity, a)
     };
@@ -240,14 +240,14 @@ where
         prover
             .input_assignment
             .into_iter()
-            .map(|s| s.to_le_bits())
+            .map(|s| s.into())
             .collect::<Vec<_>>(),
     );
     let aux_assignment = Arc::new(
         prover
             .aux_assignment
             .into_iter()
-            .map(|s| s.to_le_bits())
+            .map(|s| s.into())
             .collect::<Vec<_>>(),
     );
 


### PR DESCRIPTION
`BitArray` iteration is slower in `bitvec 1.0` than `bitvec 0.22`. The refactor minimises the amount of bit iteration done in `multiexp`, avoiding repeated iteration across parallel workers.