### PR TITLE
parallel exponent chunks to regain multiexp performance regression

### DIFF
--- a/src/multiexp.rs
+++ b/src/multiexp.rs
@@ -280,7 +280,7 @@ where
     // Split the exponents into chunks.
     let exponents = Arc::new(
         exponents
-            .iter()
+            .par_iter()
             .map(|exp| exp.chunks(c as usize))
             .collect::<Vec<_>>(),
     );


### PR DESCRIPTION
If we parallel the exponent into chunks like in the earlier version, we can regain some performance regression.
```
multiexp/65536          time:   [409.96 ms 411.86 ms 413.81 ms]                           
                        change: [-8.6071% -7.8501% -7.1148%] (p = 0.00 < 0.05)
                        Performance has improved.
```