### PR TITLE
Prepared verifying key for batch verifying

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to Rust's notion of
 
 ## [Unreleased]
 
+### Changed
+- The `verify` and `verify_multicore` methods of batch verification for Groth16
+  now take a `PreparedVerifyingKey` instead for performance improvement.
+
 ## [0.13.1] - 2022-07-05
 ### Added
 - `bellman::groth16::batch::Verifier` now has a `verify_multicore` method (when

--- a/src/groth16/mod.rs
+++ b/src/groth16/mod.rs
@@ -407,6 +407,12 @@ pub struct PreparedVerifyingKey<E: MultiMillerLoop> {
     neg_delta_g2: E::G2Prepared,
     /// Copy of IC from `VerifiyingKey`.
     ic: Vec<E::G1Affine>,
+
+    // Batch verification needs
+    alpha_g1: E::G1Affine,
+    delta_g2: E::G2Prepared,
+    gamma_g2: E::G2Prepared,
+    beta_g2: E::G2Prepared,
 }
 
 pub trait ParameterSource<E: Engine> {

--- a/src/groth16/verifier.rs
+++ b/src/groth16/verifier.rs
@@ -17,6 +17,11 @@ pub fn prepare_verifying_key<E: MultiMillerLoop>(vk: &VerifyingKey<E>) -> Prepar
         neg_gamma_g2: gamma.into(),
         neg_delta_g2: delta.into(),
         ic: vk.ic.clone(),
+
+        alpha_g1: vk.alpha_g1,
+        delta_g2: vk.delta_g2.into(),
+        gamma_g2: vk.gamma_g2.into(),
+        beta_g2: vk.beta_g2.into(),
     }
 }
 

--- a/tests/mimc.rs
+++ b/tests/mimc.rs
@@ -182,7 +182,7 @@ fn batch_verify() {
     let batch_start = Instant::now();
 
     // Verify this batch for this specific verifying key
-    assert!(batch.verify(rng, &params.vk).is_ok());
+    assert!(batch.verify(rng, &pvk).is_ok());
 
     batch_verifying += batch_start.elapsed();
 


### PR DESCRIPTION
This forces the batch verification routines to take a `PreparedVerifyingKey` instead which avoids needless arithmetic. Breaking API change.