### PR TITLE
Migrate to `group::CurveAffine`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ and this project adheres to Rust's notion of
 [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Changed
+- MSRV bumped to `1.63.0`
+
 ### Removed
 - `bellman::groth16` (moved to the `groth16` crate).
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -115,7 +115,7 @@ dependencies = [
 [[package]]
 name = "bls12_381"
 version = "0.8.0"
-source = "git+https://github.com/zkcrypto/bls12_381.git?rev=d5df9da6b20619bf77cc432447c02f8f6a6a1fb3#d5df9da6b20619bf77cc432447c02f8f6a6a1fb3"
+source = "git+https://github.com/zkcrypto/bls12_381.git?rev=b859693951a28bb2e44515adbf54395aa8ec7a9a#b859693951a28bb2e44515adbf54395aa8ec7a9a"
 dependencies = [
  "ff",
  "group",
@@ -390,8 +390,7 @@ dependencies = [
 [[package]]
 name = "group"
 version = "0.14.0-pre.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1ff6a0b2dd4b981b1ae9e3e6830ab146771f3660d31d57bafd9018805a91b0f1"
+source = "git+https://github.com/zkcrypto/group.git?rev=21104854da7f316c470213ab4a2ace239d24dd28#21104854da7f316c470213ab4a2ace239d24dd28"
 dependencies = [
  "ff",
  "rand_core",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,6 +3,17 @@
 version = 3
 
 [[package]]
+name = "addchain"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3b2e69442aa5628ea6951fa33e24efe8313f4321a91bd729fc2f75bdfc858570"
+dependencies = [
+ "num-bigint",
+ "num-integer",
+ "num-traits",
+]
+
+[[package]]
 name = "anes"
 version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -104,8 +115,7 @@ dependencies = [
 [[package]]
 name = "bls12_381"
 version = "0.8.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d7bc6d6292be3a19e6379786dac800f551e5865a5bb51ebbe3064ab80433f403"
+source = "git+https://github.com/zkcrypto/bls12_381.git?rev=d5df9da6b20619bf77cc432447c02f8f6a6a1fb3#d5df9da6b20619bf77cc432447c02f8f6a6a1fb3"
 dependencies = [
  "ff",
  "group",
@@ -308,13 +318,29 @@ checksum = "7fcaabb2fef8c910e7f4c7ce9f67a1283a1715879a7c230ca9d6d1ae31f16d91"
 
 [[package]]
 name = "ff"
-version = "0.13.0"
+version = "0.14.0-pre.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ded41244b729663b1e574f1b4fb731469f69f79c17667b5d776b16cda0479449"
+checksum = "d42dd26f5790eda47c1a2158ea4120e32c35ddc9a7743c98a292accc01b54ef3"
 dependencies = [
  "bitvec",
+ "ff_derive",
  "rand_core",
  "subtle",
+]
+
+[[package]]
+name = "ff_derive"
+version = "0.14.0-pre.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9266df7c7c72e5a865a447aca13bf480d7310eaa4f84de117c33e361d4da8888"
+dependencies = [
+ "addchain",
+ "num-bigint",
+ "num-integer",
+ "num-traits",
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
 ]
 
 [[package]]
@@ -335,13 +361,14 @@ dependencies = [
 
 [[package]]
 name = "getrandom"
-version = "0.2.8"
+version = "0.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c05aeb6a22b8f62540c194aac980f2115af067bfe15a0734d7277a768d396b31"
+checksum = "899def5c37c4fd7b2664648c28120ecec138e4d395b459e5ca34f9cce2dd77fd"
 dependencies = [
  "cfg-if",
  "libc",
- "wasi",
+ "r-efi",
+ "wasip2",
 ]
 
 [[package]]
@@ -362,9 +389,9 @@ dependencies = [
 
 [[package]]
 name = "group"
-version = "0.13.0"
+version = "0.14.0-pre.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f0f9ef7462f7c099f518d754361858f86d8a07af53ba9af0fe635bbccb151a63"
+checksum = "1ff6a0b2dd4b981b1ae9e3e6830ab146771f3660d31d57bafd9018805a91b0f1"
 dependencies = [
  "ff",
  "rand_core",
@@ -449,9 +476,9 @@ checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
 
 [[package]]
 name = "libc"
-version = "0.2.140"
+version = "0.2.182"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "99227334921fae1a979cf0bfdfcc6b3e5ce376ef57e16fb6fb3ea2ed6095f80c"
+checksum = "6800badb6cb2082ffd7b6a67e6125bb39f18782f793520caee8cb8846be06112"
 
 [[package]]
 name = "log"
@@ -469,6 +496,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d61c719bcfbcf5d62b3a09efa6088de8c54bc0bfcd3ea7ae39fcc186108b8de1"
 dependencies = [
  "autocfg",
+]
+
+[[package]]
+name = "num-bigint"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5f6f7833f2cbf2360a6cfd58cd41a53aa7a90bd4c202f5b1c7dd2ed73c57b2c3"
+dependencies = [
+ "autocfg",
+ "num-integer",
+ "num-traits",
+]
+
+[[package]]
+name = "num-integer"
+version = "0.1.46"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7969661fd2958a5cb096e56c8e1ad0444ac2bbcd0061bd28660485a44879858f"
+dependencies = [
+ "num-traits",
 ]
 
 [[package]]
@@ -510,9 +557,9 @@ checksum = "9b7820b9daea5457c9f21c69448905d723fbd21136ccf521748f23fd49e723ee"
 
 [[package]]
 name = "pairing"
-version = "0.23.0"
+version = "0.24.0-pre.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "81fec4625e73cf41ef4bb6846cafa6d44736525f442ba45e407c4a000a13996f"
+checksum = "6da2718d0978f43d6cd2ad0eee1531c6e58c71a852a9fb01590f174973409039"
 dependencies = [
  "group",
 ]
@@ -570,6 +617,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "r-efi"
+version = "5.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f"
+
+[[package]]
 name = "radium"
 version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -577,20 +630,19 @@ checksum = "dc33ff2d4973d518d823d61aa239014831e521c75da58e3df4840d3f47749d09"
 
 [[package]]
 name = "rand"
-version = "0.8.5"
+version = "0.9.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404"
+checksum = "6db2770f06117d490610c7488547d543617b21bfa07796d7a12f6f1bd53850d1"
 dependencies = [
- "libc",
  "rand_chacha",
  "rand_core",
 ]
 
 [[package]]
 name = "rand_chacha"
-version = "0.3.1"
+version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e6c10a63a0fa32252be49d21e7709d4d4baf8d231c2dbce1eaa8141b9b127d88"
+checksum = "d3022b5f1df60f26e1ffddd6c66e8aa15de382ae63b3a0c1bfc0e4d3e3f325cb"
 dependencies = [
  "ppv-lite86",
  "rand_core",
@@ -598,18 +650,18 @@ dependencies = [
 
 [[package]]
 name = "rand_core"
-version = "0.6.4"
+version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
+checksum = "76afc826de14238e6e8c374ddcc1fa19e374fd8dd986b0d2af0d02377261d83c"
 dependencies = [
  "getrandom",
 ]
 
 [[package]]
 name = "rand_xorshift"
-version = "0.3.0"
+version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d25bf25ec5ae4a3f1b92f929810509a2f53d7dca2f50b794ff57e3face536c8f"
+checksum = "513962919efc330f829edb2535844d1b912b0fbe2ca165d613e4e8788bb05a5a"
 dependencies = [
  "rand_core",
 ]
@@ -793,10 +845,13 @@ dependencies = [
 ]
 
 [[package]]
-name = "wasi"
-version = "0.11.0+wasi-snapshot-preview1"
+name = "wasip2"
+version = "1.0.2+wasi-0.2.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
+checksum = "9517f9239f02c069db75e65f174b3da828fe5f5b945c4dd26bd25d89c03ebcf5"
+dependencies = [
+ "wit-bindgen",
+]
 
 [[package]]
 name = "wasm-bindgen"
@@ -892,6 +947,12 @@ name = "winapi-x86_64-pc-windows-gnu"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
+
+[[package]]
+name = "wit-bindgen"
+version = "0.51.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d7249219f66ced02969388cf2bb044a09756a083d0fab1e566056b04d9fbcaa5"
 
 [[package]]
 name = "wyz"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,10 +22,10 @@ rust-version = "1.63"
 [dependencies]
 bitvec = "1"
 blake2s_simd = "1"
-ff = "0.13"
-group = "0.13"
-pairing = { version = "0.23", optional = true }
-rand_core = "0.6"
+ff = "=0.14.0-pre.0"
+group = "=0.14.0-pre.0"
+pairing = { version = "=0.24.0-pre.0", optional = true }
+rand_core = "0.9"
 byteorder = "1"
 subtle = "2.2.1"
 
@@ -40,16 +40,16 @@ rayon = { version = "1.5.1", optional = true }
 bls12_381 = "0.8"
 criterion = "0.4"
 hex-literal = "0.3"
-pairing = "0.23"
-rand = "0.8"
-rand_xorshift = "0.3"
+pairing = "=0.24.0-pre.0"
+rand = "0.9"
+rand_xorshift = "0.4"
 sha2 = "0.10"
 
 # Only for doctests.
 groth16 = { path = "groth16" }
 
 [features]
-multicore = ["crossbeam-channel", "lazy_static", "log", "num_cpus", "rayon", "rand_core/getrandom"]
+multicore = ["crossbeam-channel", "lazy_static", "log", "num_cpus", "rayon"]
 default = ["multicore"]
 
 [[bench]]
@@ -58,3 +58,6 @@ harness = false
 
 [badges]
 maintenance = { status = "actively-developed" }
+
+[patch.crates-io]
+bls12_381 = { git = "https://github.com/zkcrypto/bls12_381.git", rev = "d5df9da6b20619bf77cc432447c02f8f6a6a1fb3" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -60,4 +60,5 @@ harness = false
 maintenance = { status = "actively-developed" }
 
 [patch.crates-io]
-bls12_381 = { git = "https://github.com/zkcrypto/bls12_381.git", rev = "d5df9da6b20619bf77cc432447c02f8f6a6a1fb3" }
+bls12_381 = { git = "https://github.com/zkcrypto/bls12_381.git", rev = "b859693951a28bb2e44515adbf54395aa8ec7a9a" }
+group = { git = "https://github.com/zkcrypto/group.git", rev = "21104854da7f316c470213ab4a2ace239d24dd28" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,7 @@ name = "bellman"
 repository = "https://github.com/zkcrypto/bellman"
 version = "0.14.0"
 edition = "2021"
-rust-version = "1.60"
+rust-version = "1.63"
 
 [dependencies]
 bitvec = "1"

--- a/groth16/Cargo.toml
+++ b/groth16/Cargo.toml
@@ -16,15 +16,15 @@ license = "MIT OR Apache-2.0"
 [dependencies]
 bellman = { version = "0.14", path = "../" }
 byteorder = "1"
-ff = "0.13"
-group = "0.13"
-pairing = "0.23"
-rand_core = "0.6"
+ff = "=0.14.0-pre.0"
+group = "=0.14.0-pre.0"
+pairing = "=0.24.0-pre.0"
+rand_core = "0.9"
 
 [dev-dependencies]
 bls12_381 = "0.8"
 criterion = "0.4"
-rand = "0.8"
+rand = "0.9"
 subtle = "2.2.1"
 
 [[bench]]

--- a/groth16/src/generator.rs
+++ b/groth16/src/generator.rs
@@ -3,7 +3,7 @@ use std::ops::{AddAssign, MulAssign};
 use std::sync::Arc;
 
 use ff::{Field, PrimeField};
-use group::{prime::PrimeCurveAffine, Curve, Group, Wnaf, WnafGroup};
+use group::{Curve, CurveAffine, Group, Wnaf, WnafGroup};
 use pairing::Engine;
 
 use super::{Parameters, VerifyingKey};

--- a/groth16/src/lib.rs
+++ b/groth16/src/lib.rs
@@ -2,7 +2,7 @@
 //!
 //! [Groth16]: https://eprint.iacr.org/2016/260
 
-use group::{prime::PrimeCurveAffine, GroupEncoding, UncompressedEncoding};
+use group::{CurveAffine, GroupEncoding, UncompressedEncoding};
 use pairing::{Engine, MultiMillerLoop};
 
 use bellman::{multiexp::SourceBuilder, SynthesisError};

--- a/groth16/src/prover.rs
+++ b/groth16/src/prover.rs
@@ -3,7 +3,7 @@ use std::ops::{AddAssign, MulAssign};
 use std::sync::Arc;
 
 use ff::{Field, PrimeField, PrimeFieldBits};
-use group::{prime::PrimeCurveAffine, Curve};
+use group::{Curve, CurveAffine};
 use pairing::Engine;
 
 use super::{ParameterSource, Proof};

--- a/groth16/src/tests/dummy_engine.rs
+++ b/groth16/src/tests/dummy_engine.rs
@@ -1,7 +1,7 @@
 use ff::{Field, FieldBits, PrimeField, PrimeFieldBits};
 use group::{
-    prime::{PrimeCurve, PrimeCurveAffine, PrimeGroup},
-    Curve, Group, GroupEncoding, UncompressedEncoding, WnafGroup,
+    prime::{PrimeCurve, PrimeGroup},
+    Curve, CurveAffine, Group, GroupEncoding, UncompressedEncoding, WnafGroup,
 };
 use pairing::{Engine, MillerLoopResult, MultiMillerLoop, PairingCurveAffine};
 
@@ -404,7 +404,7 @@ impl Group for Fr {
 impl PrimeGroup for Fr {}
 
 impl Curve for Fr {
-    type AffineRepr = Fr;
+    type Affine = Fr;
 
     fn to_affine(&self) -> Fr {
         *self
@@ -417,9 +417,7 @@ impl WnafGroup for Fr {
     }
 }
 
-impl PrimeCurve for Fr {
-    type Affine = Fr;
-}
+impl PrimeCurve for Fr {}
 
 #[derive(Copy, Clone, Default)]
 pub struct FakePoint;
@@ -436,7 +434,7 @@ impl AsRef<[u8]> for FakePoint {
     }
 }
 
-impl PrimeCurveAffine for Fr {
+impl CurveAffine for Fr {
     type Curve = Fr;
     type Scalar = Fr;
 

--- a/groth16/src/tests/dummy_engine.rs
+++ b/groth16/src/tests/dummy_engine.rs
@@ -5,7 +5,7 @@ use group::{
 };
 use pairing::{Engine, MillerLoopResult, MultiMillerLoop, PairingCurveAffine};
 
-use rand_core::RngCore;
+use rand_core::TryRngCore;
 use std::iter::Sum;
 use std::num::Wrapping;
 use std::ops::{Add, AddAssign, BitAnd, Mul, MulAssign, Neg, Shr, Sub, SubAssign};
@@ -200,8 +200,8 @@ impl Field for Fr {
     const ZERO: Self = Fr(Wrapping(0));
     const ONE: Self = Fr(Wrapping(1));
 
-    fn random(mut rng: impl RngCore) -> Self {
-        Fr(Wrapping(rng.next_u32()) % MODULUS_R)
+    fn try_from_rng<R: TryRngCore + ?Sized>(rng: &mut R) -> Result<Self, R::Error> {
+        Ok(Fr(Wrapping(rng.try_next_u32()?) % MODULUS_R))
     }
 
     fn is_zero(&self) -> Choice {
@@ -380,8 +380,8 @@ impl MillerLoopResult for Fr {
 impl Group for Fr {
     type Scalar = Fr;
 
-    fn random(rng: impl RngCore) -> Self {
-        <Fr as Field>::random(rng)
+    fn try_from_rng<R: TryRngCore + ?Sized>(rng: &mut R) -> Result<Self, R::Error> {
+        <Fr as Field>::try_from_rng(rng)
     }
 
     fn identity() -> Self {

--- a/groth16/src/verifier.rs
+++ b/groth16/src/verifier.rs
@@ -1,4 +1,4 @@
-use group::{prime::PrimeCurveAffine, Curve};
+use group::{Curve, CurveAffine};
 use pairing::{MillerLoopResult, MultiMillerLoop};
 use std::ops::{AddAssign, Neg};
 

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,3 +1,3 @@
 [toolchain]
-channel = "1.60.0"
+channel = "1.63.0"
 components = ["clippy", "rustfmt"]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -24,7 +24,6 @@
 //! };
 //! use bls12_381::Bls12;
 //! use ff::PrimeField;
-//! use rand::rngs::OsRng;
 //! use sha2::{Digest, Sha256};
 //!
 //! /// Our own SHA-256d gadget. Input and output are in little-endian bit order.
@@ -95,11 +94,13 @@
 //!     }
 //! }
 //!
+//! let mut rng = rand::rng();
+//!
 //! // Create parameters for our circuit. In a production deployment these would
 //! // be generated securely using a multiparty computation.
 //! let params = {
 //!     let c = MyCircuit { preimage: None };
-//!     groth16::generate_random_parameters::<Bls12, _, _>(c, &mut OsRng).unwrap()
+//!     groth16::generate_random_parameters::<Bls12, _, _>(c, &mut rng).unwrap()
 //! };
 //!
 //! // Prepare the verification key (for proof verification).
@@ -115,7 +116,7 @@
 //! };
 //!
 //! // Create a Groth16 proof with our parameters.
-//! let proof = groth16::create_random_proof(c, &params, &mut OsRng).unwrap();
+//! let proof = groth16::create_random_proof(c, &params, &mut rng).unwrap();
 //!
 //! // Pack the hash as inputs for proof verification.
 //! let hash_bits = multipack::bytes_to_bits_le(&hash);

--- a/src/multiexp.rs
+++ b/src/multiexp.rs
@@ -32,11 +32,11 @@ pub trait Source<G: PrimeCurveAffine> {
 
 pub trait AddAssignFromSource: PrimeCurve {
     /// Parses the element from the source. Fails if the point is at infinity.
-    fn add_assign_from_source<S: Source<<Self as PrimeCurve>::Affine>>(
+    fn add_assign_from_source<S: Source<Self::Affine>>(
         &mut self,
         source: &mut S,
     ) -> Result<(), SynthesisError> {
-        AddAssign::<&<Self as PrimeCurve>::Affine>::add_assign(self, source.next()?);
+        AddAssign::<&Self::Affine>::add_assign(self, source.next()?);
         Ok(())
     }
 }
@@ -218,7 +218,7 @@ where
     D: Send + Sync + 'static + Clone + AsRef<Q>,
     G: PrimeCurve,
     G::Scalar: PrimeFieldBits,
-    S: SourceBuilder<<G as PrimeCurve>::Affine>,
+    S: SourceBuilder<G::Affine>,
 {
     // Perform this region of the multiexp
     let this = move |bases: S,
@@ -313,7 +313,7 @@ where
     D: Send + Sync + 'static + Clone + AsRef<Q>,
     G: PrimeCurve,
     G::Scalar: PrimeFieldBits,
-    S: SourceBuilder<<G as PrimeCurve>::Affine>,
+    S: SourceBuilder<G::Affine>,
 {
     let c = if exponents.len() < 32 {
         3u32
@@ -335,7 +335,7 @@ where
 #[test]
 fn test_with_bls12() {
     fn naive_multiexp<G: PrimeCurve>(
-        bases: Arc<Vec<<G as PrimeCurve>::Affine>>,
+        bases: Arc<Vec<G::Affine>>,
         exponents: Arc<Vec<G::Scalar>>,
     ) -> G {
         assert_eq!(bases.len(), exponents.len());


### PR DESCRIPTION
Depends on https://github.com/zkcrypto/group/pull/48 and https://github.com/zkcrypto/bls12_381/pull/109.