### PR TITLE
Docs improvements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,7 +42,7 @@ and this project adheres to Rust's notion of
 
 ## [0.11.2] - 2022-05-04
 ### Fixed
-- Groth16 prover now correctly computes query densitites with respect to linear
+- Groth16 prover now correctly computes query densities with respect to linear
   combinations that contain coefficients of zero.
 - Fixed an infinite recursion bug in the `Display` implementation for `SynthesisError`.
 

--- a/src/gadgets/boolean.rs
+++ b/src/gadgets/boolean.rs
@@ -6,7 +6,7 @@ use crate::{ConstraintSystem, LinearCombination, SynthesisError, Variable};
 
 use super::Assignment;
 
-/// Represents a variable in the constraint system which is guaranteed
+/// Represents a variable in the constraint system that is guaranteed
 /// to be either zero or one.
 #[derive(Clone)]
 pub struct AllocatedBit {

--- a/src/gadgets/num.rs
+++ b/src/gadgets/num.rs
@@ -1,4 +1,4 @@
-//! Gadgets representing numbers in the scalar field of the underlying curve.
+//! Gadgets represent numbers in the scalar field of the underlying curve.
 
 use ff::{PrimeField, PrimeFieldBits};
 

--- a/src/groth16/prover.rs
+++ b/src/groth16/prover.rs
@@ -113,7 +113,7 @@ impl<S: PrimeField> ConstraintSystem<S> for ProvingAssignment<S> {
         self.a.push(Scalar(eval(
             &a,
             // Inputs have full density in the A query
-            // because there are constraints of the
+            // because there are constraints on the
             // form x * 0 = 0 for each input.
             None,
             Some(&mut self.a_aux_density),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,5 +1,5 @@
 //! `bellman` is a crate for building zk-SNARK circuits. It provides circuit
-//! traits and and primitive structures, as well as basic gadget implementations
+//! traits and primitive structures, as well as basic gadget implementations
 //! such as booleans and number abstractions.
 //!
 //! # Example circuit

--- a/tests/mimc.rs
+++ b/tests/mimc.rs
@@ -4,7 +4,7 @@ use rand::thread_rng;
 // For benchmarking
 use std::time::{Duration, Instant};
 
-// Bring in some tools for using finite fiels
+// Bring in some tools for using finite fields
 use ff::Field;
 
 // We're going to use the BLS12-381 pairing-friendly elliptic curve.


### PR DESCRIPTION
Rectify typographical inaccuracies

This PR addresses several typographical errors across various files in the project. The changes improve readability and maintain the professional standard of the documentation and code comments.

Justification
Typographical errors, while minor, can detract from the overall quality of the project. Correcting these errors ensures clarity and professionalism, making the project more accessible and understandable for current and future contributors.