### PR TITLE
 Fix typos in documentation and error messages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,7 +44,7 @@ and this project adheres to Rust's notion of
 
 ## [0.11.2] - 2022-05-04
 ### Fixed
-- Groth16 prover now correctly computes query densitites with respect to linear
+- Groth16 prover now correctly computes query densities with respect to linear
   combinations that contain coefficients of zero.
 - Fixed an infinite recursion bug in the `Display` implementation for `SynthesisError`.
 

--- a/groth16/src/lib.rs
+++ b/groth16/src/lib.rs
@@ -404,7 +404,7 @@ pub struct PreparedVerifyingKey<E: MultiMillerLoop> {
     neg_gamma_g2: E::G2Prepared,
     /// -delta in G2
     neg_delta_g2: E::G2Prepared,
-    /// Copy of IC from `VerifiyingKey`.
+    /// Copy of IC from `VerifyingKey`.
     ic: Vec<E::G1Affine>,
 }
 


### PR DESCRIPTION

## Changes

### 1. In `groth16/src/lib.rs`:
- Old: `/// Copy of IC from 'VerifiyingKey'`
- New: `/// Copy of IC from 'VerifyingKey'`

### 2. In `CHANGELOG.md`:
- Old: `Groth16 prover now correctly computes query densitites`
- New: `Groth16 prover now correctly computes query densities`

## Motivation
These changes fix spelling errors to improve code readability and documentation accuracy:

1. "VerifiyingKey" had an extra 'i' which was incorrect
2. "densitites" was misspelled and should be "densities"

The corrections ensure consistent and professional documentation throughout the codebase.

## Type of change
- [x] Documentation update
- [x] Bug fix (non-breaking change which fixes typos)

## Testing
No testing required as these are documentation-only changes.