### PR TITLE
fix: typos in documentation files

### DIFF
--- a/groth16/src/lib.rs
+++ b/groth16/src/lib.rs
@@ -404,7 +404,7 @@ pub struct PreparedVerifyingKey<E: MultiMillerLoop> {
     neg_gamma_g2: E::G2Prepared,
     /// -delta in G2
     neg_delta_g2: E::G2Prepared,
-    /// Copy of IC from `VerifiyingKey`.
+    /// Copy of IC from `VerifyingKey`.
     ic: Vec<E::G1Affine>,
 }
 

--- a/groth16/tests/mimc.rs
+++ b/groth16/tests/mimc.rs
@@ -4,7 +4,7 @@ use rand::thread_rng;
 // For benchmarking
 use std::time::{Duration, Instant};
 
-// Bring in some tools for using finite fiels
+// Bring in some tools for using finite fields
 use ff::Field;
 
 // We're going to use the BLS12-381 pairing-friendly elliptic curve.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,5 +1,5 @@
 //! `bellman` is a crate for building zk-SNARK circuits. It provides circuit
-//! traits and and primitive structures, as well as basic gadget implementations
+//! traits and primitive structures, as well as basic gadget implementations
 //! such as booleans and number abstractions.
 //!
 //! # Example circuit


### PR DESCRIPTION
Corrected `VerifiyingKey` to `VerifyingKey`  
Corrected `fiels` to `fields`  
Corrected `traits and and primitive` to `traits and primitive`  