### PR TITLE
Update actions/checkout from v3 to v4

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,7 +11,7 @@ jobs:
         os: [ubuntu-latest, windows-latest, macOS-latest]
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Run tests
         run: cargo test --verbose --release --workspace
 
@@ -27,7 +27,7 @@ jobs:
           build_flags: --no-default-features --features groth16
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Add target
         run: rustup target add ${{ matrix.target }}
       - name: Build for target
@@ -38,7 +38,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       # Build benchmarks to prevent bitrot
       - name: Build benchmarks
         run: cargo build --benches --workspace --all-features
@@ -47,7 +47,7 @@ jobs:
     name: Intra-doc links
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       # Requires #![deny(rustdoc::broken_intra_doc_links)] in crates.
       - name: Check intra-doc links
         run: cargo doc --workspace --document-private-items
@@ -57,6 +57,6 @@ jobs:
     timeout-minutes: 30
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Check formatting
         run: cargo fmt --all -- --check


### PR DESCRIPTION
This PR updates the GitHub Actions checkout action from v3 to v4 across all workflow jobs.

Changes:
- Updated actions/checkout@v3 to actions/checkout@v4 in test job
- Updated actions/checkout@v3 to actions/checkout@v4 in target build job
- Updated actions/checkout@v3 to actions/checkout@v4 in benchmark job

This update ensures we're using the latest version of the checkout action which includes performance improvements and bug fixes.