### PR TITLE
update actions/checkout from v3 to v4 

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,7 +11,7 @@ jobs:
         os: [ubuntu-latest, windows-latest, macOS-latest]
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Run tests
         run: cargo test --verbose --release --workspace
 
@@ -27,7 +27,7 @@ jobs:
           build_flags: --no-default-features --features groth16
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Add target
         run: rustup target add ${{ matrix.target }}
       - name: Build for target
@@ -38,7 +38,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       # Build benchmarks to prevent bitrot
       - name: Build benchmarks
         run: cargo build --benches --workspace --all-features
@@ -47,7 +47,7 @@ jobs:
     name: Intra-doc links
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       # Requires #![deny(rustdoc::broken_intra_doc_links)] in crates.
       - name: Check intra-doc links
         run: cargo doc --workspace --document-private-items

--- a/.github/workflows/lints-stable.yml
+++ b/.github/workflows/lints-stable.yml
@@ -9,7 +9,7 @@ jobs:
     timeout-minutes: 30
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Run clippy
         uses: actions-rs/clippy-check@v1
         with:


### PR DESCRIPTION
Updates actions/checkout to the latest stable version v4.

Changes:

Updates all instances of actions/checkout@v3 to actions/checkout@v4

Reference:
Latest version confirmation: https://github.com/actions/checkout/releases/tag/v4.2.2

This update ensures we're using the most recent stable version of the GitHub checkout action across our CI/CD pipelines.